### PR TITLE
ci: implement fully automated CI/CD pipeline for binaries and docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI Pipeline
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  validate:
+    name: Lint & Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+          components: clippy, rustfmt
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "network-node -> target"
+
+      - name: Install NPM dependencies
+        run: npm ci
+
+      - name: Run Linter
+        run: make lint
+
+      - name: Run Tests
+        run: make test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: Release Pipeline
+
+on:
+  push:
+    tags:
+      - 'v*' # Triggers on semantic versioning tags (e.g., v1.0.0)
+
+permissions:
+  contents: write    # Required to upload assets to GitHub Releases
+  packages: write    # Required to push Docker images to GHCR
+
+jobs:
+  publish-binaries:
+    name: Build & Attach Release Binaries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build Network Node (Release)
+        run: cd network-node && cargo build --release
+
+      - name: Rename and Compress Binary
+        run: |
+          mv network-node/target/release/network-node axionvera-network-linux-amd64
+          tar -czvf axionvera-network-linux-amd64.tar.gz axionvera-network-linux-amd64
+
+      - name: Upload Binary to GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: axionvera-network-linux-amd64.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-docker:
+    name: Build & Push Distroless Docker Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry (GHCR)
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+
+      - name: Build and Push Image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
### Summary
Introduced an industrial-grade CI/CD pipeline to automatically test, build, and publish deployment artifacts securely whenever new code is merged or tagged.

Closes #15

### Pipeline Architecture
#### 1. Continuous Integration (`ci.yml`)
- Triggers on all PRs and pushes to `main`.
- Integrates with the repository `Makefile` to enforce `make lint` and `make test`.
- Implements `Swatinem/rust-cache` and Node caching to significantly reduce CI execution times.

#### 2. Continuous Delivery / Release (`release.yml`)
- Triggers exclusively on semantic version tags (`v*`).
- **Binary Distribution:** Compiles the Rust `network-node` in release mode, packages it as a tarball, and securely attaches it to the GitHub Releases page using `softprops/action-gh-release`.
- **Docker Distribution:** Builds the multi-stage distroless Docker image (from Issue #311) using `docker/buildx` and pushes it directly to the GitHub Container Registry (GHCR) with automatic semantic tagging.

### Security & Optimization
- Minimal permissions applied via the `permissions` block (`contents: write`, `packages: write`).
- Docker build leverages GitHub Actions native caching (`type=gha`) to speed up consecutive image builds.