### PR TITLE
build(docker): Optimize Dockerfile for the Rust Node (Multi-stage Build) (#100)

### DIFF
--- a/HPA_IMPLEMENTATION.md
+++ b/HPA_IMPLEMENTATION.md
@@ -338,3 +338,13 @@ This implementation successfully addresses Issue #420 by providing:
 - ✅ Comprehensive monitoring and testing
 
 The solution provides a robust, scalable foundation for handling network traffic spikes while maintaining system stability and preventing oscillation through proper stabilization mechanisms.
+
+## Local Testing with Minikube
+
+To verify the HPA configuration locally before deploying to production, you can use `minikube` along with a load-generation tool.
+
+### 1. Enable Required Addons
+The HPA requires the Kubernetes Metrics Server to fetch CPU/Memory metrics.
+```bash
+minikube addons enable metrics-server
+```

--- a/network-node/Dockerfile
+++ b/network-node/Dockerfile
@@ -1,0 +1,43 @@
+# ─── Stage 1: Chef Setup ──────────────────────────────────────────────────────
+FROM rust:1.75-bookworm AS chef
+# We only pay the installation cost once, then cache the layer
+RUN cargo install cargo-chef
+WORKDIR /app
+
+# ─── Stage 2: Planner ─────────────────────────────────────────────────────────
+FROM chef AS planner
+COPY . .
+# Compute a lock-like recipe file for our project dependencies
+RUN cargo chef prepare --recipe-path recipe.json
+
+# ─── Stage 3: Builder ─────────────────────────────────────────────────────────
+FROM chef AS builder
+# Install system dependencies required for RocksDB and Tonic (gRPC/Protobufs)
+RUN apt-get update && apt-get install -y \
+    clang llvm libclang-dev pkg-config libssl-dev protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=planner /app/recipe.json recipe.json
+# Build dependencies - this is the massive caching layer!
+# It drastically speeds up rebuilds if your Cargo.toml hasn't changed.
+RUN cargo chef cook --release --recipe-path recipe.json
+
+# Build application
+COPY . .
+# The binary name should match your package name in Cargo.toml
+RUN cargo build --release --bin axionvera-network-node
+
+# ─── Stage 4: Production Runtime ──────────────────────────────────────────────
+# We use the distroless C++ image because RocksDB dynamically links to libstdc++
+# The :nonroot tag ensures we run as a restricted user from the start
+FROM gcr.io/distroless/cc-debian12:nonroot AS runtime
+WORKDIR /app
+
+# Copy ONLY the compiled binary from the builder environment
+COPY --from=builder --chown=nonroot:nonroot /app/target/release/axionvera-network-node /app/axionvera-network-node
+
+# Expose gRPC (50051) and Prometheus Metrics (9090) ports
+EXPOSE 50051 9090
+
+# Set the binary as the entrypoint
+ENTRYPOINT ["/app/axionvera-network-node"]


### PR DESCRIPTION
## Description
This PR resolves Issue #100 by introducing a dedicated, highly-optimized Docker build pipeline for the Rust network node.

While the existing root `Dockerfile` correctly handled the Soroban WASM compilation, it did not containerize the actual network node service. This PR introduces a multi-stage architecture utilizing `cargo-chef` to drastically reduce image size, speed up CI/CD rebuilds, and securely package the node for our Kubernetes cluster.

**Key Additions:**
- **`network-node/Dockerfile`**: A new multi-stage build targeted exclusively at the `axionvera-network-node` executable.
- **`cargo-chef` Integration**: Separates dependency compilation from source code compilation. Docker now natively caches the compiled dependencies, making subsequent rebuilds lightning fast.
- **System Dependencies**: Explicitly installs `clang`, `libssl-dev`, and `protobuf-compiler` in the builder stage to ensure `rocksdb` and `tonic` compile flawlessly.
- **Distroless Runtime**: The final stage inherits from `gcr.io/distroless/cc-debian12:nonroot` (required over plain distroless due to RocksDB's C++ standard library linking). 
- **Security**: The container strips all shell access and executes strictly as a restricted `nonroot` user.

Closes #100

## Type of Change
- [x] DevOps / Infrastructure
- [x] Security & Performance

## Validation
- [x] Confirmed the final image copies *only* the compiled release binary.
- [x] Runs securely as a non-root user in a minimal, shell-less distroless environment.
- [x] Correctly exposes the `50051` (gRPC) and `9090` (Prometheus Metrics) ports.