### PR TITLE
Implement vault gRPC TVL handler

### DIFF
--- a/network-node/src/database.rs
+++ b/network-node/src/database.rs
@@ -86,6 +86,21 @@ impl ConnectionPool {
         .await
         .map_err(|e| crate::error::NetworkError::Database(DatabaseError::QueryFailed(e.to_string())))?;
 
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS deposits (
+                id SERIAL PRIMARY KEY,
+                user_address TEXT NOT NULL,
+                token_address TEXT NOT NULL,
+                amount NUMERIC NOT NULL,
+                transaction_hash TEXT,
+                ledger_sequence INTEGER,
+                created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+            )"
+        )
+        .execute(&self.pool)
+        .await
+        .map_err(|e| crate::error::NetworkError::Database(DatabaseError::QueryFailed(e.to_string())))?;
+
         info!("Database schema initialized successfully");
         Ok(())
     }

--- a/network-node/src/grpc/mod.rs
+++ b/network-node/src/grpc/mod.rs
@@ -10,8 +10,10 @@ pub mod network_service;
 pub mod gateway_service;
 pub mod health_service;
 pub mod p2p_service;
+pub mod vault_service;
 
 pub use network_service::NetworkServiceImpl;
 pub use gateway_service::GatewayServiceImpl;
 pub use health_service::HealthServiceImpl;
 pub use p2p_service::P2PServiceImpl;
+pub use vault_service::VaultServiceImpl;

--- a/network-node/src/grpc/server.rs
+++ b/network-node/src/grpc/server.rs
@@ -11,8 +11,9 @@ use crate::database::ConnectionPool;
 use crate::error::NetworkError;
 use crate::signing::SigningService;
 use crate::grpc::{
-    NetworkServiceImpl, GatewayServiceImpl, HealthServiceImpl, P2PServiceImpl,
+    NetworkServiceImpl, GatewayServiceImpl, HealthServiceImpl, P2PServiceImpl, VaultServiceImpl,
     network::network_service_server::NetworkServiceServer,
+    network::vault_service_server::VaultServiceServer,
     network::health_service_server::HealthServiceServer,
     network::p2p_service_server::P2PServiceServer,
     gateway::gateway_service_server::GatewayServiceServer,
@@ -92,6 +93,7 @@ impl GrpcServer {
 
         let health_service = HealthServiceImpl::new(self.connection_pool.clone());
         let p2p_service = P2PServiceImpl::new(self.p2p_manager.clone());
+        let vault_service = VaultServiceImpl::new(self.connection_pool.clone());
 
         // Build the gRPC server with middleware
         let mut server = Server::builder()
@@ -102,6 +104,10 @@ impl GrpcServer {
             .add_service(
                 GatewayServiceServer::new(gateway_service)
                     .max_decoding_message_size(4 * 1024 * 1024)
+            )
+            .add_service(
+                VaultServiceServer::new(vault_service)
+                    .max_decoding_message_size(1024 * 1024)
             )
             .add_service(
                 HealthServiceServer::new(health_service)

--- a/network-node/src/grpc/vault_service.rs
+++ b/network-node/src/grpc/vault_service.rs
@@ -1,0 +1,50 @@
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
+use tonic::{Request, Response, Status};
+use tracing::{error, info};
+
+use crate::database::ConnectionPool;
+use crate::grpc::network::{
+    vault_service_server::VaultService, GetTvlRequest, GetTvlResponse,
+};
+
+pub struct VaultServiceImpl {
+    connection_pool: Arc<RwLock<ConnectionPool>>,
+}
+
+impl VaultServiceImpl {
+    pub fn new(connection_pool: Arc<RwLock<ConnectionPool>>) -> Self {
+        Self { connection_pool }
+    }
+}
+
+#[tonic::async_trait]
+impl VaultService for VaultServiceImpl {
+    async fn get_tvl(
+        &self,
+        _request: Request<GetTvlRequest>,
+    ) -> Result<Response<GetTvlResponse>, Status> {
+        info!("Received vault TVL request");
+
+        let pool = {
+            let connection_pool = self.connection_pool.read().await;
+            connection_pool.get_pool().clone()
+        };
+
+        let tvl: String = sqlx::query_scalar(
+            "SELECT COALESCE(SUM(amount), 0)::TEXT FROM deposits",
+        )
+        .fetch_one(&pool)
+        .await
+        .map_err(|err| {
+            error!("Failed to fetch vault TVL: {}", err);
+            match err {
+                sqlx::Error::RowNotFound => Status::not_found("vault deposits not found"),
+                _ => Status::internal("failed to fetch vault TVL"),
+            }
+        })?;
+
+        Ok(Response::new(GetTvlResponse { tvl }))
+    }
+}

--- a/proto/network.proto
+++ b/proto/network.proto
@@ -32,6 +32,11 @@ service NetworkService {
   rpc ListPendingParameterUpgrades(google.protobuf.Empty) returns (PendingParameterUpgradesResponse);
 }
 
+// Vault service for vault-specific aggregate queries.
+service VaultService {
+  rpc GetTVL(GetTvlRequest) returns (GetTvlResponse);
+}
+
 // P2P network service for peer-to-peer communication
 service P2PService {
   rpc ConnectToPeer(PeerConnectionRequest) returns (PeerConnectionResponse);
@@ -127,6 +132,12 @@ message ContractStateResponse {
   uint64 total_users = 4;
   google.protobuf.Timestamp last_updated = 5;
   map<string, string> custom_state = 6;
+}
+
+message GetTvlRequest {}
+
+message GetTvlResponse {
+  string tvl = 1;
 }
 
 // Network status messages


### PR DESCRIPTION
Closes #97

---

## Summary

Implements the Vault gRPC service handler for TVL queries.

## Changes

- Added `VaultService` and `GetTVL` protobuf definitions.
- Added `VaultServiceImpl` for the generated Tonic `VaultService` trait.
- Registered `VaultServiceServer` with the existing gRPC server.
- Connected the handler to the shared PostgreSQL connection pool.
- Implemented `GetTVL` using:

  ```sql
  SELECT COALESCE(SUM(amount), 0)::TEXT FROM deposits
