### PR TITLE
fix: add auth interceptor for privileged grpc routes

### DIFF
--- a/network-node/src/grpc/server.rs
+++ b/network-node/src/grpc/server.rs
@@ -1,9 +1,11 @@
 use std::sync::Arc;
 use std::net::SocketAddr;
+use sha2::{Digest, Sha256};
 use tokio::sync::RwLock;
-use tonic::transport::{Server, Certificate, Identity, ServerTlsConfig};
-use tonic_web::GrpcWebLayer;
-use tower::ServiceBuilder;
+use tonic::metadata::MetadataMap;
+use tonic::service::{interceptor, Interceptor};
+use tonic::transport::{Identity, Server, ServerTlsConfig};
+use tonic::{Request, Status};
 use tracing::{info, error, warn};
 
 use crate::config::NetworkConfig;
@@ -20,6 +22,98 @@ use crate::grpc::{
 use crate::state_trie::StateTrie;
 use crate::p2p::P2PManager;
 use crate::chain_params::ChainParameterRegistry;
+
+const ADMIN_GRPC_PATHS: [&str; 4] = [
+    "/axionvera.network.NetworkService/DistributeRewards",
+    "/axionvera.network.NetworkService/ParameterUpgrade",
+    "/axionvera.gateway.GatewayService/DistributeRewards",
+    "/axionvera.gateway.GatewayService/ParameterUpgrade",
+];
+
+fn is_admin_grpc_route(path: &str) -> bool {
+    ADMIN_GRPC_PATHS.contains(&path)
+}
+
+fn sha256_hex(value: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(value.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+fn extract_admin_token(metadata: &MetadataMap) -> Option<String> {
+    if let Some(raw_auth_header) = metadata
+        .get("authorization")
+        .and_then(|value| value.to_str().ok())
+    {
+        let auth_header = raw_auth_header.trim();
+        if let Some((scheme, token)) = auth_header.split_once(' ') {
+            if scheme.eq_ignore_ascii_case("bearer") {
+                let bearer_token = token.trim();
+                if !bearer_token.is_empty() {
+                    return Some(bearer_token.to_string());
+                }
+            }
+        }
+    }
+
+    for key in ["x-api-key", "api-key"] {
+        if let Some(raw_api_key) = metadata.get(key).and_then(|value| value.to_str().ok()) {
+            let api_key = raw_api_key.trim();
+            if !api_key.is_empty() {
+                return Some(api_key.to_string());
+            }
+        }
+    }
+
+    None
+}
+
+#[derive(Clone, Debug)]
+struct AdminAuthInterceptor {
+    expected_token_hash: Option<Arc<str>>,
+}
+
+impl AdminAuthInterceptor {
+    fn from_env() -> Self {
+        Self::new(std::env::var("GRPC_ADMIN_AUTH_TOKEN_HASH").ok())
+    }
+
+    fn new(expected_token_hash: Option<String>) -> Self {
+        let expected_token_hash = expected_token_hash
+            .map(|hash| hash.trim().to_ascii_lowercase())
+            .filter(|hash| !hash.is_empty())
+            .map(Arc::<str>::from);
+
+        Self { expected_token_hash }
+    }
+
+    fn is_configured(&self) -> bool {
+        self.expected_token_hash.is_some()
+    }
+}
+
+impl Interceptor for AdminAuthInterceptor {
+    fn call(&mut self, request: Request<()>) -> Result<Request<()>, Status> {
+        let path = request.uri().path();
+        if !is_admin_grpc_route(path) {
+            return Ok(request);
+        }
+
+        let expected_hash = self.expected_token_hash.as_deref().ok_or_else(|| {
+            Status::unauthenticated("admin authentication is not configured")
+        })?;
+
+        let provided_token = extract_admin_token(request.metadata()).ok_or_else(|| {
+            Status::unauthenticated("missing authorization token")
+        })?;
+
+        if sha256_hex(&provided_token) != expected_hash {
+            return Err(Status::unauthenticated("invalid authorization token"));
+        }
+
+        Ok(request)
+    }
+}
 
 pub struct GrpcServer {
     config: NetworkConfig,
@@ -74,6 +168,13 @@ impl GrpcServer {
 
         info!("Starting gRPC server on {}", addr);
 
+        let admin_auth_interceptor = AdminAuthInterceptor::from_env();
+        if !admin_auth_interceptor.is_configured() {
+            warn!(
+                "GRPC_ADMIN_AUTH_TOKEN_HASH is not set; administrative gRPC routes will reject requests"
+            );
+        }
+
         // Create service implementations
         let chain_cp = self.chain_parameters.clone();
         let network_service = NetworkServiceImpl::new(
@@ -93,16 +194,22 @@ impl GrpcServer {
         let health_service = HealthServiceImpl::new(self.connection_pool.clone());
         let p2p_service = P2PServiceImpl::new(self.p2p_manager.clone());
 
+        let network_service = interceptor(
+            NetworkServiceServer::new(network_service)
+                .max_decoding_message_size(4 * 1024 * 1024), // 4MB max message size
+            admin_auth_interceptor.clone(),
+        );
+
+        let gateway_service = interceptor(
+            GatewayServiceServer::new(gateway_service)
+                .max_decoding_message_size(4 * 1024 * 1024),
+            admin_auth_interceptor.clone(),
+        );
+
         // Build the gRPC server with middleware
         let mut server = Server::builder()
-            .add_service(
-                NetworkServiceServer::new(network_service)
-                    .max_decoding_message_size(4 * 1024 * 1024) // 4MB max message size
-            )
-            .add_service(
-                GatewayServiceServer::new(gateway_service)
-                    .max_decoding_message_size(4 * 1024 * 1024)
-            )
+            .add_service(network_service)
+            .add_service(gateway_service)
             .add_service(
                 HealthServiceServer::new(health_service)
                     .max_decoding_message_size(1024 * 1024) // 1MB for health checks
@@ -114,14 +221,17 @@ impl GrpcServer {
 
         // Add gRPC-Web support for browser clients
         server = server.add_service(
-            GatewayServiceServer::new(GatewayServiceImpl::new(
-                self.connection_pool.clone(),
-                self.state_trie.clone(),
-                self.p2p_manager.clone(),
-                self.chain_parameters.clone(),
-            ))
-            .accept_compressed(tonic::codec::CompressionEncoding::Gzip)
-            .send_compressed(tonic::codec::CompressionEncoding::Gzip)
+            interceptor(
+                GatewayServiceServer::new(GatewayServiceImpl::new(
+                    self.connection_pool.clone(),
+                    self.state_trie.clone(),
+                    self.p2p_manager.clone(),
+                    self.chain_parameters.clone(),
+                ))
+                .accept_compressed(tonic::codec::CompressionEncoding::Gzip)
+                .send_compressed(tonic::codec::CompressionEncoding::Gzip),
+                admin_auth_interceptor.clone(),
+            )
         );
 
         // Configure TLS if certificates are provided
@@ -152,7 +262,7 @@ impl GrpcServer {
 
         // Apply interceptors for logging and metrics
         server = server.intercept_fn(|req| {
-            info!("gRPC request: method={:?}, metadata={:?}", req.method(), req.metadata());
+            info!("gRPC request: path={}", req.uri().path());
             Ok(req)
         });
 
@@ -226,5 +336,87 @@ impl GrpcGateway {
         info!("Use the gRPC endpoint directly: {}", self.grpc_address);
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tonic::metadata::MetadataValue;
+
+    fn test_request(path: &str) -> Request<()> {
+        Request::from_http(
+            http::Request::builder()
+                .uri(path)
+                .body(())
+                .expect("failed to build test request"),
+        )
+    }
+
+    #[test]
+    fn admin_route_without_token_is_rejected() {
+        let mut interceptor = AdminAuthInterceptor::new(Some(sha256_hex("test-token")));
+        let request = test_request("/axionvera.network.NetworkService/DistributeRewards");
+
+        let error = interceptor.call(request).expect_err("request should fail");
+        assert_eq!(error.code(), tonic::Code::Unauthenticated);
+    }
+
+    #[test]
+    fn admin_route_with_valid_bearer_token_is_allowed() {
+        let mut interceptor = AdminAuthInterceptor::new(Some(sha256_hex("test-token")));
+        let mut request = test_request("/axionvera.network.NetworkService/DistributeRewards");
+        request.metadata_mut().insert(
+            "authorization",
+            MetadataValue::try_from("Bearer test-token").expect("invalid metadata value"),
+        );
+
+        assert!(interceptor.call(request).is_ok());
+    }
+
+    #[test]
+    fn admin_route_with_valid_api_key_is_allowed() {
+        let mut interceptor = AdminAuthInterceptor::new(Some(sha256_hex("test-token")));
+        let mut request = test_request("/axionvera.gateway.GatewayService/ParameterUpgrade");
+        request.metadata_mut().insert(
+            "x-api-key",
+            MetadataValue::try_from("test-token").expect("invalid metadata value"),
+        );
+
+        assert!(interceptor.call(request).is_ok());
+    }
+
+    #[test]
+    fn admin_route_with_invalid_token_is_rejected() {
+        let mut interceptor = AdminAuthInterceptor::new(Some(sha256_hex("valid-token")));
+        let mut request = test_request("/axionvera.network.NetworkService/ParameterUpgrade");
+        request.metadata_mut().insert(
+            "authorization",
+            MetadataValue::try_from("Bearer wrong-token").expect("invalid metadata value"),
+        );
+
+        let error = interceptor.call(request).expect_err("request should fail");
+        assert_eq!(error.code(), tonic::Code::Unauthenticated);
+    }
+
+    #[test]
+    fn public_route_without_token_is_allowed() {
+        let mut interceptor = AdminAuthInterceptor::new(Some(sha256_hex("test-token")));
+        let request = test_request("/axionvera.network.NetworkService/GetBalance");
+
+        assert!(interceptor.call(request).is_ok());
+    }
+
+    #[test]
+    fn admin_route_is_rejected_when_auth_not_configured() {
+        let mut interceptor = AdminAuthInterceptor::new(None);
+        let mut request = test_request("/axionvera.gateway.GatewayService/DistributeRewards");
+        request.metadata_mut().insert(
+            "x-api-key",
+            MetadataValue::try_from("test-token").expect("invalid metadata value"),
+        );
+
+        let error = interceptor.call(request).expect_err("request should fail");
+        assert_eq!(error.code(), tonic::Code::Unauthenticated);
     }
 }


### PR DESCRIPTION
Closes #98

## Summary
Adds authentication enforcement to privileged gRPC operations, including reward distribution and chain parameter upgrade endpoints.

## Root Cause
The active gRPC server wiring in `server.rs` registered services without an auth interceptor — only logging middleware was present, leaving admin endpoints publicly accessible.

## Fix
Added `AdminAuthInterceptor` in `server.rs` that:
- Reads metadata for `Authorization` Bearer token and API key headers
- Validates token by SHA-256 hash comparison against `GRPC_ADMIN_AUTH_TOKEN_HASH`
- Returns `unauthenticated` when token is missing or invalid
- Enforces checks only on admin RPC paths, leaving non-admin/read-only routes public

## Testing
- ✅ Focused unit tests added covering admin allow/deny cases and public-route pass-through
- ✅ Diagnostics on the changed file pass
