### PR TITLE
feat(vault): implement contract pausing mechanism

### DIFF
--- a/contracts/vault-contract/src/errors.rs
+++ b/contracts/vault-contract/src/errors.rs
@@ -20,6 +20,7 @@ pub enum StateError {
     AlreadyInitialized,
     NotInitialized,
     InvalidState,
+    ContractPaused,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -71,6 +72,7 @@ pub enum VaultError {
     ReentrancyDetected = 13,
     InvalidState = 14,
     ZeroRewardIncrement = 15,
+    ContractPaused = 16,
 }
 
 impl VaultError {
@@ -148,6 +150,10 @@ impl VaultError {
                 category: ErrorCategory::Math,
                 message: "reward increment is zero",
             },
+            Self::ContractPaused => ErrorInfo {
+                category: ErrorCategory::State,
+                message: "contract is paused",
+            },
         }
     }
 
@@ -179,6 +185,7 @@ impl From<StateError> for VaultError {
             StateError::AlreadyInitialized => Self::AlreadyInitialized,
             StateError::NotInitialized => Self::NotInitialized,
             StateError::InvalidState => Self::InvalidState,
+            StateError::ContractPaused => Self::ContractPaused,
         }
     }
 }

--- a/contracts/vault-contract/src/lib.rs
+++ b/contracts/vault-contract/src/lib.rs
@@ -23,6 +23,7 @@ impl VaultContract {
         deposit_token: Address,
         reward_token: Address,
     ) -> Result<(), VaultError> {
+        storage::require_not_paused(&e)?;
         if storage::is_initialized(&e) {
             return Err(StateError::AlreadyInitialized.into());
         }
@@ -39,6 +40,7 @@ impl VaultContract {
     /// Deposits tokens into the vault and accrues pending rewards before updating balance.
     /// This ensures users receive rewards based on their old balance up to this point.
     pub fn deposit(e: Env, from: Address, amount: i128) -> Result<(), VaultError> {
+        storage::require_not_paused(&e)?;
         storage::require_initialized(&e)?;
         validate_positive_amount(amount)?;
         from.require_auth();
@@ -73,6 +75,7 @@ impl VaultContract {
     /// Distributes rewards to all depositors by updating the global reward index.
     /// Does not immediately transfer rewards to users - they accrue lazily.
     pub fn distribute_rewards(e: Env, amount: i128) -> Result<i128, VaultError> {
+        storage::require_not_paused(&e)?;
         storage::require_initialized(&e)?;
         validate_positive_amount(amount)?;
 
@@ -139,6 +142,28 @@ impl VaultContract {
 
     pub fn reward_token(e: Env) -> Result<Address, VaultError> {
         storage::get_reward_token(&e)
+    }
+
+    pub fn pause_contract(e: Env, admin: Address) -> Result<(), VaultError> {
+        storage::require_initialized(&e)?;
+        let current_admin = storage::get_admin(&e)?;
+        if current_admin != admin {
+            return Err(VaultError::Unauthorized);
+        }
+        admin.require_auth();
+        storage::set_paused(&e, true);
+        Ok(())
+    }
+
+    pub fn unpause_contract(e: Env, admin: Address) -> Result<(), VaultError> {
+        storage::require_initialized(&e)?;
+        let current_admin = storage::get_admin(&e)?;
+        if current_admin != admin {
+            return Err(VaultError::Unauthorized);
+        }
+        admin.require_auth();
+        storage::set_paused(&e, false);
+        Ok(())
     }
 }
 

--- a/contracts/vault-contract/src/storage.rs
+++ b/contracts/vault-contract/src/storage.rs
@@ -22,6 +22,7 @@ pub enum DataKey {
     UserBalance(Address),
     UserRewardIndex(Address),
     UserRewards(Address),
+    IsPaused,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -48,6 +49,23 @@ pub fn enter_non_reentrant(e: &Env) -> Result<(), VaultError> {
 
 pub fn set_initialized(e: &Env) {
     e.storage().instance().set(&DataKey::Initialized, &true);
+    bump_instance_ttl(e);
+}
+
+pub fn is_paused(e: &Env) -> bool {
+    e.storage().instance().get(&DataKey::IsPaused).unwrap_or(false)
+}
+
+pub fn require_not_paused(e: &Env) -> Result<(), VaultError> {
+    if is_paused(e) {
+        Err(StateError::ContractPaused.into())
+    } else {
+        Ok(())
+    }
+}
+
+pub fn set_paused(e: &Env, paused: bool) {
+    e.storage().instance().set(&DataKey::IsPaused, &paused);
     bump_instance_ttl(e);
 }
 


### PR DESCRIPTION
This PR closes #76 
 PR Description

Title: feat: implement emergency contract pausing mechanism

 Description
Implements an emergency response feature to allow the Vault Admin to instantly halt deposits and reward distributions. This protects user funds in the event of a zero-day exploit in the Soroban SDK or the vault contract, fulfilling standard requirements for institutional liquidity providers.

 Changes Made
* Added an `IsPaused` boolean key (`DataKey::IsPaused`) to the contract state.
* Implemented `pause_contract(env: Env, admin: Address)` and `unpause_contract(env: Env, admin: Address)` in `lib.rs`. Both functions strictly enforce `admin.require_auth()` and verify that the provided admin matches the vault's current admin.
* Added a `storage::require_not_paused(&e)?` explicit check at the beginning of `initialize`, `deposit`, and `distribute_rewards` functions to assert that the contract is active.
* Kept the `withdraw` and `claim_rewards` functions isolated from the pausing logic, ensuring that users can always exit the system and retrieve their assets even during an emergency halt.
* Updated `VaultError` and `StateError` in `errors.rs` to include a structured `ContractPaused` variant.

 How It Was Tested
* Pause Enforcement: Verified that attempting to call `deposit`, `distribute_rewards`, or `initialize` while the contract is paused correctly aborts the transaction and returns a `ContractPaused` error.
* Exit Liquidity Guarantee: Verified that users can successfully execute `withdraw` and `claim_rewards` to retrieve their deposits and accrued rewards even when the contract is in a paused state.
* Authorization Checks: Verified that `pause_contract` and `unpause_contract` only succeed when called by the currently authorized Vault Admin, rejecting calls from unauthorized addresses.
* Resumption of Services: Verified that calling `unpause_contract` successfully restores normal vault operations, permitting deposits and reward distributions to process as normal.
