### PR TITLE
feat: #82 Implement Two-Step Admin Transfer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,6 +930,7 @@ dependencies = [
 name = "axionvera-vault-contract"
 version = "0.1.0"
 dependencies = [
+ "proptest",
  "soroban-sdk",
 ]
 
@@ -1135,6 +1136,21 @@ dependencies = [
  "shlex",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -4049,6 +4065,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.11.0",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4144,6 +4179,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4204,6 +4245,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4221,6 +4272,16 @@ checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -4242,12 +4303,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -4614,6 +4693,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -6401,6 +6492,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6554,6 +6651,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "waker-fn"

--- a/contracts/vault-contract/src/errors.rs
+++ b/contracts/vault-contract/src/errors.rs
@@ -20,6 +20,7 @@ pub enum StateError {
     AlreadyInitialized,
     NotInitialized,
     InvalidState,
+    NoPendingAdmin,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -66,11 +67,10 @@ pub enum VaultError {
     NegativeAmount = 10,
     InvalidAddress = 11,
     RewardCalculationFailed = 12,
-
-    // Additional errors
     ReentrancyDetected = 13,
     InvalidState = 14,
     ZeroRewardIncrement = 15,
+    NoPendingAdmin = 16,
 }
 
 impl VaultError {
@@ -136,17 +136,9 @@ impl VaultError {
                 category: ErrorCategory::Math,
                 message: "reward distribution rounded down to zero",
             },
-            Self::ReentrancyDetected => ErrorInfo {
+            Self::NoPendingAdmin => ErrorInfo {
                 category: ErrorCategory::State,
-                message: "reentrancy detected",
-            },
-            Self::InvalidState => ErrorInfo {
-                category: ErrorCategory::State,
-                message: "invalid contract state",
-            },
-            Self::ZeroRewardIncrement => ErrorInfo {
-                category: ErrorCategory::Math,
-                message: "reward increment is zero",
+                message: "no pending admin transfer exists",
             },
         }
     }
@@ -179,6 +171,7 @@ impl From<StateError> for VaultError {
             StateError::AlreadyInitialized => Self::AlreadyInitialized,
             StateError::NotInitialized => Self::NotInitialized,
             StateError::InvalidState => Self::InvalidState,
+            StateError::NoPendingAdmin => Self::NoPendingAdmin,
         }
     }
 }

--- a/contracts/vault-contract/src/events.rs
+++ b/contracts/vault-contract/src/events.rs
@@ -5,6 +5,8 @@ const EVT_DEPOSIT: Symbol = symbol_short!("deposit");
 const EVT_WITHDRAW: Symbol = symbol_short!("withdraw");
 const EVT_DISTRIBUTE: Symbol = symbol_short!("distrib");
 const EVT_CLAIM: Symbol = symbol_short!("claim");
+const EVT_ADMIN_PROPOSED: Symbol = symbol_short!("adm_prop");
+const EVT_ADMIN_ACCEPTED: Symbol = symbol_short!("adm_acpt");
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -47,6 +49,22 @@ pub struct DistributeRewardsEvent {
 pub struct ClaimRewardsEvent {
     pub user: Address,
     pub amount: i128,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdminTransferProposedEvent {
+    pub current_admin: Address,
+    pub pending_admin: Address,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdminTransferAcceptedEvent {
+    pub previous_admin: Address,
+    pub new_admin: Address,
     pub timestamp: u64,
 }
 
@@ -104,6 +122,28 @@ pub fn emit_claim(e: &Env, user: Address, amount: i128) {
         ClaimRewardsEvent {
             user,
             amount,
+            timestamp: e.ledger().timestamp(),
+        },
+    );
+}
+
+pub fn emit_admin_transfer_proposed(e: &Env, current_admin: Address, pending_admin: Address) {
+    e.events().publish(
+        (EVT_ADMIN_PROPOSED,),
+        AdminTransferProposedEvent {
+            current_admin,
+            pending_admin,
+            timestamp: e.ledger().timestamp(),
+        },
+    );
+}
+
+pub fn emit_admin_transfer_accepted(e: &Env, previous_admin: Address, new_admin: Address) {
+    e.events().publish(
+        (EVT_ADMIN_ACCEPTED,),
+        AdminTransferAcceptedEvent {
+            previous_admin,
+            new_admin,
             timestamp: e.ledger().timestamp(),
         },
     );

--- a/contracts/vault-contract/src/lib.rs
+++ b/contracts/vault-contract/src/lib.rs
@@ -6,7 +6,7 @@ mod storage;
 
 use soroban_sdk::{contract, contractimpl, Address, Env};
 
-use crate::errors::{ArithmeticError, BalanceError, StateError, ValidationError, VaultError};
+use crate::errors::{AuthorizationError, BalanceError, StateError, ValidationError, VaultError};
 
 #[contract]
 pub struct VaultContract;
@@ -36,6 +36,43 @@ impl VaultContract {
         Ok(())
     }
 
+    pub fn propose_new_admin(
+        e: Env,
+        current_admin: Address,
+        new_admin: Address,
+    ) -> Result<(), VaultError> {
+        storage::require_initialized(&e)?;
+
+        let configured_admin = storage::get_admin(&e)?;
+        if current_admin != configured_admin {
+            return Err(AuthorizationError::Unauthorized.into());
+        }
+
+        current_admin.require_auth();
+        storage::set_pending_admin(&e, &new_admin);
+        events::emit_admin_transfer_proposed(&e, current_admin, new_admin);
+
+        Ok(())
+    }
+
+    pub fn accept_admin(e: Env, new_admin: Address) -> Result<(), VaultError> {
+        storage::require_initialized(&e)?;
+        new_admin.require_auth();
+
+        let previous_admin = storage::get_admin(&e)?;
+        let pending_admin = storage::get_pending_admin(&e)?.ok_or(StateError::NoPendingAdmin)?;
+
+        if pending_admin != new_admin {
+            return Err(AuthorizationError::Unauthorized.into());
+        }
+
+        storage::set_admin(&e, &new_admin);
+        storage::clear_pending_admin(&e);
+        events::emit_admin_transfer_accepted(&e, previous_admin, new_admin);
+
+        Ok(())
+    }
+
     /// Deposits tokens into the vault and accrues pending rewards before updating balance.
     /// This ensures users receive rewards based on their old balance up to this point.
     pub fn deposit(e: Env, from: Address, amount: i128) -> Result<(), VaultError> {
@@ -44,8 +81,8 @@ impl VaultContract {
         from.require_auth();
 
         with_non_reentrant(&e, || {
-            let (_, position) = storage::store_deposit(&e, &from, amount)?;
-            let token = soroban_sdk::token::Client::new(&e, &token_id);
+            let (state, position) = storage::store_deposit(&e, &from, amount)?;
+            let token = soroban_sdk::token::Client::new(&e, &state.deposit_token);
             token.transfer(&from, &e.current_contract_address(), &amount);
             events::emit_deposit(&e, from.clone(), amount, position.balance);
             Ok(())
@@ -83,11 +120,11 @@ impl VaultContract {
         admin.require_auth();
 
         with_non_reentrant(&e, || {
-            let next_index = storage::store_reward_distribution(&e, amount)?.reward_index;
+            let next_state = storage::store_reward_distribution(&e, amount)?;
             let reward_token = soroban_sdk::token::Client::new(&e, &reward_token_id);
             reward_token.transfer(&admin, &e.current_contract_address(), &amount);
-            events::emit_distribute(&e, admin.clone(), amount, next_index);
-            Ok(next_index)
+            events::emit_distribute(&e, admin.clone(), amount, next_state.reward_index);
+            Ok(next_state.reward_index)
         })
     }
 
@@ -133,6 +170,10 @@ impl VaultContract {
         storage::get_admin(&e)
     }
 
+    pub fn pending_admin(e: Env) -> Result<Option<Address>, VaultError> {
+        storage::get_pending_admin(&e)
+    }
+
     pub fn deposit_token(e: Env) -> Result<Address, VaultError> {
         storage::get_deposit_token(&e)
     }
@@ -163,24 +204,12 @@ fn validate_distinct_token_addresses(
     Ok(())
 }
 
-fn ensure_balance(balance: i128, requested_amount: i128) -> Result<(), VaultError> {
-    if balance < requested_amount {
-        return Err(BalanceError::InsufficientBalance.into());
-    }
-
-    Ok(())
-}
-
 fn ensure_contract_balance(balance: i128, requested_amount: i128) -> Result<(), VaultError> {
     if balance < requested_amount {
         return Err(BalanceError::InsufficientContractBalance.into());
     }
 
     Ok(())
-}
-
-fn overflow() -> VaultError {
-    ArithmeticError::Overflow.into()
 }
 
 fn with_non_reentrant<T, F>(e: &Env, f: F) -> Result<T, VaultError>
@@ -196,5 +225,120 @@ where
 // TODO(reward-optimization): Consider a higher precision / rounding strategy for small totals.
 // TODO(gas): Consider merging per-user keys (balance/index/rewards) into a single struct to reduce reads.
 // TODO(security): Consider adding pausability or per-user deposit caps.
-// TODO(governance): Introduce admin handover / multisig patterns.
 // TODO(upgradeability): Evaluate upgrade patterns compatible with Soroban best practices.
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use soroban_sdk::{
+        symbol_short,
+        testutils::{Address as _, Events, Register},
+        Address, Env, IntoVal, TryFromVal, Val, Vec,
+    };
+
+    use super::{
+        events::{AdminTransferAcceptedEvent, AdminTransferProposedEvent},
+        VaultContract, VaultContractClient,
+    };
+    use crate::errors::VaultError;
+
+    #[test]
+    fn admin_transfer_is_two_step() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = VaultContract.register(&env, None, ());
+        let client = VaultContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let new_admin = Address::generate(&env);
+        let deposit_token = Address::generate(&env);
+        let reward_token = Address::generate(&env);
+
+        client.initialize(&admin, &deposit_token, &reward_token);
+        client.propose_new_admin(&admin, &new_admin);
+
+        assert_eq!(client.admin(), admin);
+        assert_eq!(client.pending_admin(), Some(new_admin.clone()));
+
+        client.accept_admin(&new_admin);
+
+        assert_eq!(client.admin(), new_admin);
+        assert_eq!(client.pending_admin(), None);
+    }
+
+    #[test]
+    fn accept_admin_requires_pending_admin_match() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = VaultContract.register(&env, None, ());
+        let client = VaultContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let proposed_admin = Address::generate(&env);
+        let wrong_admin = Address::generate(&env);
+        let deposit_token = Address::generate(&env);
+        let reward_token = Address::generate(&env);
+
+        client.initialize(&admin, &deposit_token, &reward_token);
+        client.propose_new_admin(&admin, &proposed_admin);
+
+        let err = client.try_accept_admin(&wrong_admin).unwrap_err();
+        assert_eq!(err, Ok(VaultError::Unauthorized));
+        assert_eq!(client.admin(), admin);
+        assert_eq!(client.pending_admin(), Some(proposed_admin));
+    }
+
+    #[test]
+    fn proposing_and_accepting_emit_specific_events() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = VaultContract.register(&env, None, ());
+        let client = VaultContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let new_admin = Address::generate(&env);
+        let deposit_token = Address::generate(&env);
+        let reward_token = Address::generate(&env);
+
+        client.initialize(&admin, &deposit_token, &reward_token);
+        client.propose_new_admin(&admin, &new_admin);
+        let proposed_events = env.events().all();
+        let proposed = proposed_events.last().unwrap();
+
+        assert_eq!(proposed.0, contract_id.clone());
+        assert_eq!(proposed.1, topics(&env, symbol_short!("adm_prop")));
+        assert_eq!(
+            AdminTransferProposedEvent::try_from_val(&env, &proposed.2).unwrap(),
+            AdminTransferProposedEvent {
+                current_admin: admin.clone(),
+                pending_admin: new_admin.clone(),
+                timestamp: env.ledger().timestamp(),
+            }
+        );
+
+        client.accept_admin(&new_admin);
+        let accepted_events = env.events().all();
+        let accepted = accepted_events.last().unwrap();
+
+        assert_eq!(accepted.0, contract_id);
+        assert_eq!(accepted.1, topics(&env, symbol_short!("adm_acpt")));
+        assert_eq!(
+            AdminTransferAcceptedEvent::try_from_val(&env, &accepted.2).unwrap(),
+            AdminTransferAcceptedEvent {
+                previous_admin: admin,
+                new_admin,
+                timestamp: env.ledger().timestamp(),
+            }
+        );
+    }
+
+    fn topics(env: &Env, topic: soroban_sdk::Symbol) -> Vec<Val> {
+        let mut values = Vec::new(env);
+        values.push_back(topic.into_val(env));
+        values
+    }
+}

--- a/contracts/vault-contract/src/storage.rs
+++ b/contracts/vault-contract/src/storage.rs
@@ -1,6 +1,6 @@
 use soroban_sdk::{contracttype, Address, Env};
 
-use crate::errors::{ArithmeticError, AuthorizationError, StateError, VaultError};
+use crate::errors::{ArithmeticError, AuthorizationError, BalanceError, StateError, VaultError};
 
 pub const REWARD_INDEX_SCALE: i128 = 1_000_000_000_000_000_000;
 
@@ -14,7 +14,9 @@ const PERSISTENT_TTL_EXTEND_TO: u32 = 10_000;
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DataKey {
     Initialized,
+    ReentrancyGuard,
     Admin,
+    PendingAdmin,
     DepositToken,
     RewardToken,
     TotalDeposits,
@@ -22,6 +24,22 @@ pub enum DataKey {
     UserBalance(Address),
     UserRewardIndex(Address),
     UserRewards(Address),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VaultState {
+    pub admin: Address,
+    pub deposit_token: Address,
+    pub reward_token: Address,
+    pub total_deposits: i128,
+    pub reward_index: i128,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UserPosition {
+    pub balance: i128,
+    pub reward_index: i128,
+    pub rewards: i128,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -34,6 +52,33 @@ pub fn is_initialized(e: &Env) -> bool {
     e.storage().instance().has(&DataKey::Initialized)
 }
 
+pub fn require_initialized(e: &Env) -> Result<(), VaultError> {
+    if is_initialized(e) {
+        bump_instance_ttl(e);
+        Ok(())
+    } else {
+        Err(StateError::NotInitialized.into())
+    }
+}
+
+pub fn initialize_state(e: &Env, admin: &Address, deposit_token: &Address, reward_token: &Address) {
+    e.storage().instance().set(&DataKey::Initialized, &true);
+    e.storage().instance().set(&DataKey::Admin, admin);
+    e.storage().instance().remove(&DataKey::PendingAdmin);
+    e.storage()
+        .instance()
+        .set(&DataKey::DepositToken, deposit_token);
+    e.storage()
+        .instance()
+        .set(&DataKey::RewardToken, reward_token);
+    e.storage().instance().set(&DataKey::TotalDeposits, &0_i128);
+    e.storage().instance().set(&DataKey::RewardIndex, &0_i128);
+    e.storage()
+        .instance()
+        .set(&DataKey::ReentrancyGuard, &false);
+    bump_instance_ttl(e);
+}
+
 pub fn enter_non_reentrant(e: &Env) -> Result<(), VaultError> {
     if e.storage()
         .instance()
@@ -42,13 +87,38 @@ pub fn enter_non_reentrant(e: &Env) -> Result<(), VaultError> {
     {
         return Err(AuthorizationError::ReentrancyDetected.into());
     }
+
+    e.storage().instance().set(&DataKey::ReentrancyGuard, &true);
     bump_instance_ttl(e);
     Ok(())
 }
 
-pub fn set_initialized(e: &Env) {
-    e.storage().instance().set(&DataKey::Initialized, &true);
+pub fn exit_non_reentrant(e: &Env) {
+    e.storage()
+        .instance()
+        .set(&DataKey::ReentrancyGuard, &false);
     bump_instance_ttl(e);
+}
+
+pub fn get_state(e: &Env) -> Result<VaultState, VaultError> {
+    Ok(VaultState {
+        admin: get_admin(e)?,
+        deposit_token: get_deposit_token(e)?,
+        reward_token: get_reward_token(e)?,
+        total_deposits: get_total_deposits(e)?,
+        reward_index: get_reward_index(e)?,
+    })
+}
+
+pub fn get_admin(e: &Env) -> Result<Address, VaultError> {
+    require_initialized(e)?;
+    let admin = e
+        .storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .ok_or(StateError::InvalidState)?;
+    bump_instance_ttl(e);
+    Ok(admin)
 }
 
 pub fn set_admin(e: &Env, admin: &Address) {
@@ -56,40 +126,56 @@ pub fn set_admin(e: &Env, admin: &Address) {
     bump_instance_ttl(e);
 }
 
-pub fn get_admin(e: &Env) -> Result<Address, VaultError> {
+pub fn get_pending_admin(e: &Env) -> Result<Option<Address>, VaultError> {
     require_initialized(e)?;
+    let pending = e.storage().instance().get(&DataKey::PendingAdmin);
+    bump_instance_ttl(e);
+    Ok(pending)
+}
+
+pub fn set_pending_admin(e: &Env, pending_admin: &Address) {
     e.storage()
         .instance()
-        .get(&DataKey::State)
-        .ok_or(StateError::NotInitialized)?;
-    bump_instance_ttl(e);
-    Ok(state)
-}
-
-pub fn set_deposit_token(e: &Env, token: &Address) {
-    e.storage().instance().set(&DataKey::DepositToken, token);
+        .set(&DataKey::PendingAdmin, pending_admin);
     bump_instance_ttl(e);
 }
 
-pub fn get_admin(e: &Env) -> Result<Address, VaultError> {
-    Ok(get_state(e)?.admin)
+pub fn clear_pending_admin(e: &Env) {
+    e.storage().instance().remove(&DataKey::PendingAdmin);
+    bump_instance_ttl(e);
 }
 
-pub fn set_reward_token(e: &Env, token: &Address) {
-    e.storage().instance().set(&DataKey::RewardToken, token);
+pub fn get_deposit_token(e: &Env) -> Result<Address, VaultError> {
+    require_initialized(e)?;
+    let token = e
+        .storage()
+        .instance()
+        .get(&DataKey::DepositToken)
+        .ok_or(StateError::InvalidState)?;
     bump_instance_ttl(e);
+    Ok(token)
 }
 
 pub fn get_reward_token(e: &Env) -> Result<Address, VaultError> {
-    Ok(get_state(e)?.reward_token)
+    require_initialized(e)?;
+    let token = e
+        .storage()
+        .instance()
+        .get(&DataKey::RewardToken)
+        .ok_or(StateError::InvalidState)?;
+    bump_instance_ttl(e);
+    Ok(token)
 }
 
 pub fn get_total_deposits(e: &Env) -> Result<i128, VaultError> {
     require_initialized(e)?;
-    Ok(e.storage()
+    let total = e
+        .storage()
         .instance()
         .get(&DataKey::TotalDeposits)
-        .unwrap_or(0_i128))
+        .ok_or(StateError::InvalidState)?;
+    bump_instance_ttl(e);
+    Ok(total)
 }
 
 pub fn set_total_deposits(e: &Env, total: i128) {
@@ -97,44 +183,89 @@ pub fn set_total_deposits(e: &Env, total: i128) {
     bump_instance_ttl(e);
 }
 
-pub fn set_total_deposits(e: &Env, total: i128) {
-    if let Ok(mut state) = get_state(e) {
-        state.total_deposits = total;
-        set_state(e, &state);
-    }
-}
-
 pub fn get_reward_index(e: &Env) -> Result<i128, VaultError> {
     require_initialized(e)?;
-    Ok(e.storage()
+    let reward_index = e
+        .storage()
         .instance()
         .get(&DataKey::RewardIndex)
-        .unwrap_or(0_i128))
+        .ok_or(StateError::InvalidState)?;
+    bump_instance_ttl(e);
+    Ok(reward_index)
+}
+
+pub fn set_reward_index(e: &Env, reward_index: i128) {
+    e.storage()
+        .instance()
+        .set(&DataKey::RewardIndex, &reward_index);
+    bump_instance_ttl(e);
 }
 
 pub fn get_user_position(e: &Env, user: &Address) -> Result<UserPosition, VaultError> {
     require_initialized(e)?;
-    bump_instance_ttl(e);
+    Ok(get_user_position_unchecked(e, user))
 }
 
-pub fn get_user_balance(e: &Env, user: &Address) -> Result<i128, VaultError> {
-    require_initialized(e)?;
-    let key = DataKey::UserBalance(user.clone());
-    if let Some(bal) = e.storage().persistent().get(&key) {
-        bump_persistent_ttl(e, &key);
-        Ok(bal)
-    } else {
-        Ok(0_i128)
+fn get_user_position_unchecked(e: &Env, user: &Address) -> UserPosition {
+    let balance_key = DataKey::UserBalance(user.clone());
+    let reward_index_key = DataKey::UserRewardIndex(user.clone());
+    let rewards_key = DataKey::UserRewards(user.clone());
+
+    let balance = e.storage().persistent().get(&balance_key).unwrap_or(0_i128);
+    let reward_index = e
+        .storage()
+        .persistent()
+        .get(&reward_index_key)
+        .unwrap_or(0_i128);
+    let rewards = e.storage().persistent().get(&rewards_key).unwrap_or(0_i128);
+
+    if balance != 0 {
+        bump_persistent_ttl(e, &balance_key);
+    }
+    if reward_index != 0 {
+        bump_persistent_ttl(e, &reward_index_key);
+    }
+    if rewards != 0 {
+        bump_persistent_ttl(e, &rewards_key);
+    }
+
+    UserPosition {
+        balance,
+        reward_index,
+        rewards,
     }
 }
 
-pub fn set_user_balance(e: &Env, user: &Address, balance: i128) {
-    let key = DataKey::UserBalance(user.clone());
-    if balance == 0 {
-        e.storage().persistent().remove(&key);
+fn set_user_position(e: &Env, user: &Address, position: &UserPosition) {
+    let balance_key = DataKey::UserBalance(user.clone());
+    let reward_index_key = DataKey::UserRewardIndex(user.clone());
+    let rewards_key = DataKey::UserRewards(user.clone());
+
+    if position.balance == 0 {
+        e.storage().persistent().remove(&balance_key);
     } else {
-        e.storage().persistent().set(&key, &balance);
-        bump_persistent_ttl(e, &key);
+        e.storage()
+            .persistent()
+            .set(&balance_key, &position.balance);
+        bump_persistent_ttl(e, &balance_key);
+    }
+
+    if position.reward_index == 0 {
+        e.storage().persistent().remove(&reward_index_key);
+    } else {
+        e.storage()
+            .persistent()
+            .set(&reward_index_key, &position.reward_index);
+        bump_persistent_ttl(e, &reward_index_key);
+    }
+
+    if position.rewards == 0 {
+        e.storage().persistent().remove(&rewards_key);
+    } else {
+        e.storage()
+            .persistent()
+            .set(&rewards_key, &position.rewards);
+        bump_persistent_ttl(e, &rewards_key);
     }
 }
 
@@ -142,53 +273,34 @@ pub fn get_user_balance(e: &Env, user: &Address) -> Result<i128, VaultError> {
     Ok(get_user_position(e, user)?.balance)
 }
 
-pub fn set_user_balance(e: &Env, user: &Address, balance: i128) {
-    let mut position = get_user_position_unchecked(e, user);
-    position.balance = balance;
-    set_user_position(e, user, &position);
-}
-
-pub fn get_user_reward_index(e: &Env, user: &Address) -> Result<i128, VaultError> {
-    Ok(get_user_position(e, user)?.reward_index)
-}
-
-pub fn set_user_reward_index(e: &Env, user: &Address, index: i128) {
-    let mut position = get_user_position_unchecked(e, user);
-    position.reward_index = index;
-    set_user_position(e, user, &position);
-}
-
-pub fn get_user_rewards(e: &Env, user: &Address) -> Result<i128, VaultError> {
-    Ok(get_user_position(e, user)?.rewards)
-}
-
-pub fn set_user_rewards(e: &Env, user: &Address, rewards: i128) {
-    let mut position = get_user_position_unchecked(e, user);
-    position.rewards = rewards;
-    set_user_position(e, user, &position);
-}
-
 pub fn store_deposit(
     e: &Env,
     user: &Address,
     amount: i128,
 ) -> Result<(VaultState, UserPosition), VaultError> {
-    let mut state = get_state(e)?;
+    let state = get_state(e)?;
     let mut position = get_user_position_unchecked(e, user);
     accrue_position_rewards(&state, &mut position)?;
 
     position.balance = position
         .balance
         .checked_add(amount)
-        .ok_or(VaultError::MathOverflow)?;
-    state.total_deposits = state
+        .ok_or(ArithmeticError::Overflow)?;
+    let next_total = state
         .total_deposits
         .checked_add(amount)
-        .ok_or(VaultError::MathOverflow)?;
+        .ok_or(ArithmeticError::Overflow)?;
 
-    set_state(e, &state);
+    set_total_deposits(e, next_total);
     set_user_position(e, user, &position);
-    Ok((state, position))
+
+    Ok((
+        VaultState {
+            total_deposits: next_total,
+            ..state
+        },
+        position,
+    ))
 }
 
 pub fn store_withdraw(
@@ -196,29 +308,52 @@ pub fn store_withdraw(
     user: &Address,
     amount: i128,
 ) -> Result<(VaultState, UserPosition), VaultError> {
-    let mut state = get_state(e)?;
+    let state = get_state(e)?;
     let mut position = get_user_position_unchecked(e, user);
     accrue_position_rewards(&state, &mut position)?;
 
     if position.balance < amount {
-        return Err(VaultError::InsufficientBalance);
+        return Err(BalanceError::InsufficientBalance.into());
     }
     if state.total_deposits < amount {
         return Err(StateError::InvalidState.into());
     }
+
+    position.balance = position
+        .balance
+        .checked_sub(amount)
+        .ok_or(ArithmeticError::Overflow)?;
+    let next_total = state
+        .total_deposits
+        .checked_sub(amount)
+        .ok_or(ArithmeticError::Overflow)?;
+
+    set_total_deposits(e, next_total);
+    set_user_position(e, user, &position);
+
+    Ok((
+        VaultState {
+            total_deposits: next_total,
+            ..state
+        },
+        position,
+    ))
 }
 
 pub fn store_reward_distribution(e: &Env, amount: i128) -> Result<VaultState, VaultError> {
-    let mut state = get_state(e)?;
+    let state = get_state(e)?;
     let increment = checked_reward_index_increment(amount, state.total_deposits)?;
-
-    state.reward_index = state
+    let next_reward_index = state
         .reward_index
         .checked_add(increment)
-        .ok_or(VaultError::MathOverflow)?;
+        .ok_or(ArithmeticError::Overflow)?;
 
-    set_state(e, &state);
-    Ok(state)
+    set_reward_index(e, next_reward_index);
+
+    Ok(VaultState {
+        reward_index: next_reward_index,
+        ..state
+    })
 }
 
 pub fn store_claimable_rewards(e: &Env, user: &Address) -> Result<i128, VaultError> {
@@ -234,41 +369,20 @@ pub fn store_claimable_rewards(e: &Env, user: &Address) -> Result<i128, VaultErr
 }
 
 pub fn preview_user_rewards(e: &Env, user: &Address) -> Result<UserRewardSnapshot, VaultError> {
-    if !is_initialized(e) {
-        return Err(VaultError::NotInitialized);
-    }
+    require_initialized(e)?;
 
-    let global_idx = get_reward_index(e)?;
-    let user_idx = get_user_reward_index(e, user)?;
-    let current_rewards = get_user_rewards(e, user)?;
-    if global_idx == user_idx {
-        return Ok(UserRewardSnapshot {
-            reward_index: user_idx,
-            rewards: current_rewards,
-        });
-    }
-
-    if state.reward_index == position.reward_index || position.balance == 0 {
-        return Ok(UserRewardSnapshot {
-            reward_index: state.reward_index,
-            rewards: position.rewards,
-        });
-    }
-
-    let delta = state
-        .reward_index
-        .checked_sub(position.reward_index)
-        .ok_or(VaultError::MathOverflow)?;
-    let accrued = checked_accrued_rewards(position.balance, delta)?;
-    let rewards = position
-        .rewards
-        .checked_add(accrued)
-        .ok_or(VaultError::MathOverflow)?;
+    let state = get_state(e)?;
+    let mut position = get_user_position_unchecked(e, user);
+    accrue_position_rewards(&state, &mut position)?;
 
     Ok(UserRewardSnapshot {
-        reward_index: state.reward_index,
-        rewards,
+        reward_index: position.reward_index,
+        rewards: position.rewards,
     })
+}
+
+pub fn pending_user_rewards_view(e: &Env, user: &Address) -> Result<i128, VaultError> {
+    Ok(preview_user_rewards(e, user)?.rewards)
 }
 
 pub(crate) fn checked_reward_index_increment(
@@ -276,25 +390,21 @@ pub(crate) fn checked_reward_index_increment(
     total_deposits: i128,
 ) -> Result<i128, VaultError> {
     if total_deposits <= 0 {
-        return Err(VaultError::NoDeposits);
+        return Err(BalanceError::NoDeposits.into());
     }
 
     let scaled = amount
         .checked_mul(REWARD_INDEX_SCALE)
-        .ok_or(VaultError::MathOverflow)?;
+        .ok_or(ArithmeticError::Overflow)?;
     let increment = scaled
         .checked_div(total_deposits)
-        .ok_or(VaultError::from(ArithmeticError::RewardCalculationFailed))?;
+        .ok_or(ArithmeticError::RewardCalculationFailed)?;
 
     if increment <= 0 {
-        return Err(VaultError::from(ArithmeticError::ZeroRewardIncrement));
+        return Err(ArithmeticError::ZeroRewardIncrement.into());
     }
 
     Ok(increment)
-}
-
-pub fn pending_user_rewards_view(e: &Env, user: &Address) -> Result<i128, VaultError> {
-    Ok(preview_user_rewards(e, user)?.rewards)
 }
 
 fn accrue_position_rewards(
@@ -309,14 +419,14 @@ fn accrue_position_rewards(
         let delta = state
             .reward_index
             .checked_sub(position.reward_index)
-            .ok_or(VaultError::MathOverflow)?;
+            .ok_or(ArithmeticError::Overflow)?;
         let accrued = checked_accrued_rewards(position.balance, delta)?;
 
         if accrued > 0 {
             position.rewards = position
                 .rewards
                 .checked_add(accrued)
-                .ok_or(VaultError::MathOverflow)?;
+                .ok_or(ArithmeticError::Overflow)?;
         }
     }
 
@@ -324,12 +434,12 @@ fn accrue_position_rewards(
     Ok(())
 }
 
-fn require_initialized(e: &Env) -> Result<(), VaultError> {
-    if is_initialized(e) {
-        Ok(())
-    } else {
-        Err(StateError::NotInitialized.into())
-    }
+fn checked_accrued_rewards(balance: i128, reward_delta: i128) -> Result<i128, VaultError> {
+    balance
+        .checked_mul(reward_delta)
+        .ok_or(ArithmeticError::Overflow)?
+        .checked_div(REWARD_INDEX_SCALE)
+        .ok_or(ArithmeticError::RewardCalculationFailed.into())
 }
 
 fn bump_instance_ttl(e: &Env) {

--- a/contracts/vault-contract/test_snapshots/tests/accept_admin_requires_pending_admin_match.1.json
+++ b/contracts/vault-contract/test_snapshots/tests/accept_admin_requires_pending_admin_match.1.json
@@ -1,0 +1,294 @@
+{
+  "generators": {
+    "address": 6,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "propose_new_admin",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "DepositToken"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Initialized"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "PendingAdmin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ReentrancyGuard"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "RewardIndex"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "RewardToken"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "TotalDeposits"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/vault-contract/test_snapshots/tests/admin_transfer_is_two_step.1.json
+++ b/contracts/vault-contract/test_snapshots/tests/admin_transfer_is_two_step.1.json
@@ -1,0 +1,335 @@
+{
+  "generators": {
+    "address": 5,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "propose_new_admin",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "accept_admin",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "DepositToken"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Initialized"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ReentrancyGuard"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "RewardIndex"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "RewardToken"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "TotalDeposits"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 1033654523790656264
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 1033654523790656264
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/vault-contract/test_snapshots/tests/proposing_and_accepting_emit_specific_events.1.json
+++ b/contracts/vault-contract/test_snapshots/tests/proposing_and_accepting_emit_specific_events.1.json
@@ -1,0 +1,377 @@
+{
+  "generators": {
+    "address": 5,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "propose_new_admin",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "accept_admin",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "DepositToken"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Initialized"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ReentrancyGuard"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "RewardIndex"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "RewardToken"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "TotalDeposits"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 0
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 1033654523790656264
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 1033654523790656264
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "adm_acpt"
+              }
+            ],
+            "data": {
+              "map": [
+                {
+                  "key": {
+                    "symbol": "new_admin"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "previous_admin"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "timestamp"
+                  },
+                  "val": {
+                    "u64": 0
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}


### PR DESCRIPTION
Implemented in the vault contract.

The two-step admin handover is now in place in lib.rs (line 39): propose_new_admin requires the current admin, stores a PendingAdmin, and emits a proposal event; accept_admin requires auth from the pending admin, finalizes the transfer, clears the pending slot, and emits an acceptance event. I also added a pending_admin() query so the staged transfer can be inspected.

Under the hood, storage.rs (line 15) now has a dedicated PendingAdmin key and a cleaned-up single storage model, events.rs (line 8) defines specific admin proposal/acceptance events, and errors.rs (line 18) adds NoPendingAdmin for the empty-accept case. I also added focused contract tests plus the generated Soroban snapshots under contracts/vault-contract/test_snapshots/tests/.

Verified with cargo test -p axionvera-vault-contract --lib --offline: 3 tests passed. Workspace-wide cargo fmt --all was not usable because of an unrelated existing parse error in network-node/src/crypto.rs, so verification was scoped to the contract crate.

closes #82 