### PR TITLE
fix: add soroban rpc retry and failover handling

### DIFF
--- a/network-node/Cargo.toml
+++ b/network-node/Cargo.toml
@@ -54,6 +54,8 @@ aws-types = "1"
 stellar-horizon = "0.8"
 stellar_sdk = "0.1"
 reqwest = { version = "0.11", features = ["json"] }
+reqwest-middleware = "0.2"
+reqwest-retry = "0.2"
 sqlx = { version = "0.7", features = [
     "runtime-tokio-rustls",
     "postgres",

--- a/network-node/build.rs
+++ b/network-node/build.rs
@@ -1,6 +1,6 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed=../proto");
-    
+
     tonic_build::compile_protos("../proto/vault.proto")?;
     Ok(())
 }

--- a/network-node/src/config.rs
+++ b/network-node/src/config.rs
@@ -19,15 +19,45 @@ pub struct HorizonConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SorobanConfig {
+    #[serde(default = "default_soroban_rpc_url")]
     pub rpc_url: String,
+    #[serde(default)]
+    pub rpc_urls: Vec<String>,
     pub network_passphrase: String,
     pub health_check_interval_seconds: u64,
+}
+
+fn default_soroban_rpc_url() -> String {
+    "https://soroban-testnet.stellar.org:443".to_string()
+}
+
+impl SorobanConfig {
+    pub fn rpc_endpoints(&self) -> Vec<String> {
+        let mut endpoints = Vec::new();
+
+        if !self.rpc_url.trim().is_empty() {
+            endpoints.push(self.rpc_url.clone());
+        }
+
+        for rpc_url in &self.rpc_urls {
+            if !rpc_url.trim().is_empty() && !endpoints.iter().any(|url| url == rpc_url) {
+                endpoints.push(rpc_url.clone());
+            }
+        }
+
+        if endpoints.is_empty() {
+            endpoints.push(default_soroban_rpc_url());
+        }
+
+        endpoints
+    }
 }
 
 impl Default for SorobanConfig {
     fn default() -> Self {
         Self {
-            rpc_url: "https://soroban-testnet.stellar.org:443".to_string(),
+            rpc_url: default_soroban_rpc_url(),
+            rpc_urls: Vec::new(),
             network_passphrase: "Test SDF Testnet ; September 2015".to_string(),
             health_check_interval_seconds: 60,
         }

--- a/network-node/src/indexer.rs
+++ b/network-node/src/indexer.rs
@@ -1,21 +1,14 @@
-use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::time;
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, instrument};
 
 use crate::database::ConnectionPool;
-use crate::stellar_service::StellarService;
 use crate::error::NetworkError;
-
-#[derive(Debug, Serialize, Deserialize)]
-struct GetEventsRequest {
-    jsonrpc: String,
-    id: u32,
-    method: String,
-    params: GetEventsParams,
-}
+use crate::soroban_rpc_client::SorobanRpcClient;
+use crate::stellar_service::StellarService;
 
 #[derive(Debug, Serialize, Deserialize)]
 struct GetEventsParams {
@@ -31,12 +24,6 @@ struct EventFilter {
     #[serde(rename = "contractIds")]
     contract_ids: Vec<String>,
     topics: Vec<Vec<String>>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct GetEventsResponse {
-    result: Option<EventsResult>,
-    error: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -66,6 +53,7 @@ struct SorobanEventValue {
 pub struct EventIndexer {
     stellar_service: Arc<StellarService>,
     connection_pool: ConnectionPool,
+    soroban_rpc_client: Arc<SorobanRpcClient>,
     contract_id: String,
     polling_interval_secs: u64,
 }
@@ -74,75 +62,72 @@ impl EventIndexer {
     pub fn new(
         stellar_service: Arc<StellarService>,
         connection_pool: ConnectionPool,
+        soroban_rpc_client: Arc<SorobanRpcClient>,
         contract_id: String,
         polling_interval_secs: u64,
     ) -> Self {
         Self {
             stellar_service,
             connection_pool,
+            soroban_rpc_client,
             contract_id,
             polling_interval_secs,
         }
-        
-        info!("Event indexer stopped gracefully");
-        Ok(())
     }
 
     #[instrument(skip(self))]
-    pub async fn start(&self) -> Result<(), NetworkError> {
-        info!("Starting Soroban Event Indexer for contract: {}", self.contract_id);
-        
-        let client = Client::new();
-        let rpc_url = std::env::var("SOROBAN_RPC_URL").unwrap_or_else(|_| "https://soroban-testnet.stellar.org".to_string());
+    pub async fn start(&self, shutdown_token: CancellationToken) -> Result<(), NetworkError> {
+        info!(
+            "Starting Soroban Event Indexer for contract: {}",
+            self.contract_id
+        );
+
+        // Keep these dependencies initialized and available as the indexer evolves.
+        let _ = (&self.stellar_service, &self.connection_pool);
+
         let mut interval = time::interval(Duration::from_secs(self.polling_interval_secs));
         let mut current_ledger: u32 = 0;
 
         loop {
-            interval.tick().await;
-            
+            tokio::select! {
+                _ = shutdown_token.cancelled() => {
+                    info!("Event indexer stopped gracefully");
+                    return Ok(());
+                }
+                _ = interval.tick() => {}
+            }
+
             let filter = EventFilter {
                 event_type: "contract".to_string(),
                 contract_ids: vec![self.contract_id.clone()],
                 topics: vec![vec!["AxionveraVault".to_string()]],
             };
 
-            let req_body = GetEventsRequest {
-                jsonrpc: "2.0".to_string(),
-                id: 1,
-                method: "getEvents".to_string(),
-                params: GetEventsParams {
-                    start_ledger: current_ledger,
-                    filters: vec![filter],
-                },
+            let params = GetEventsParams {
+                start_ledger: current_ledger,
+                filters: vec![filter],
             };
 
-            match client.post(&rpc_url).json(&req_body).send().await {
-                Ok(response) => {
-                    if response.status().is_success() {
-                        match response.json::<GetEventsResponse>().await {
-                            Ok(rpc_response) => {
-                                if let Some(res) = rpc_response.result {
-                                    for event in res.events {
-                                        info!(
-                                            event_id = %event.id,
-                                            ledger = event.ledger,
-                                            "Parsed AxionveraVault Soroban event"
-                                        );
-                                        // Ensure sensitive XDR is truncated/omitted from INFO logs
-                                        debug!(xdr = %event.value.xdr, "Event XDR payload");
-                                    }
-                                    current_ledger = res.latest_ledger + 1;
-                                } else if let Some(err) = rpc_response.error {
-                                    error!(error = ?err, "RPC error returned");
-                                }
-                            }
-                            Err(e) => error!("Failed to parse RPC response: {}", e),
-                        }
-                    } else {
-                        error!("RPC request failed with status: {}", response.status());
+            match self
+                .soroban_rpc_client
+                .call::<_, EventsResult>("getEvents", params)
+                .await
+            {
+                Ok(events_result) => {
+                    for event in events_result.events {
+                        info!(
+                            event_id = %event.id,
+                            ledger = event.ledger,
+                            "Parsed AxionveraVault Soroban event"
+                        );
+                        debug!(xdr = %event.value.xdr, "Event XDR payload");
                     }
+
+                    current_ledger = events_result.latest_ledger + 1;
                 }
-                Err(e) => error!("Failed to connect to Soroban RPC: {}", e),
+                Err(e) => {
+                    error!(error = %e, "Failed to fetch Soroban events");
+                }
             }
         }
     }

--- a/network-node/src/lib.rs
+++ b/network-node/src/lib.rs
@@ -128,6 +128,7 @@ impl NetworkNode {
         let event_indexer = Arc::new(indexer::EventIndexer::new(
             stellar_service.clone(),
             connection_pool.read().await.clone(),
+            soroban_rpc_client.clone(),
             config.vault_contract_address.clone(),
             5, // poll interval in seconds
         ));

--- a/network-node/src/main.rs
+++ b/network-node/src/main.rs
@@ -27,6 +27,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     describe_counter!("grpc_requests_total", "Total number of gRPC requests received");
     describe_histogram!("grpc_request_duration_seconds", "gRPC request latency in seconds");
     describe_counter!("soroban_rpc_errors_total", "Total number of Soroban RPC errors encountered");
+    describe_counter!("soroban_rpc_failovers_total", "Total number of Soroban RPC endpoint failovers");
     describe_gauge!("indexer_last_ledger_processed", "The sequence number of the last ledger processed by the indexer");
     // ==========================================
 
@@ -81,9 +82,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     info!("Network node shutdown complete");
 
-
     info!("Network node shutdown complete");
-
 
     // Shutdown OpenTelemetry tracer provider
     telemetry::shutdown_tracer();

--- a/network-node/src/soroban_rpc_client.rs
+++ b/network-node/src/soroban_rpc_client.rs
@@ -1,8 +1,12 @@
-use std::time::Duration;
-use serde::{Deserialize, Serialize};
 use crate::config::SorobanConfig;
 use crate::error::{NetworkError, Result};
-use tracing::{debug, error};
+use metrics::counter;
+use reqwest::StatusCode;
+use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
+use reqwest_retry::{policies::ExponentialBackoff, RetryTransientMiddleware};
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+use tracing::{debug, error, warn};
 
 #[derive(Debug, Serialize)]
 pub struct JsonRpcRequest<T> {
@@ -66,20 +70,63 @@ pub struct SendTransactionResponse {
     pub error_result_xdr: Option<String>,
 }
 
+pub struct SorobanClient {
+    client: ClientWithMiddleware,
+}
+
+impl SorobanClient {
+    fn new(timeout: Duration) -> Self {
+        let reqwest_client = reqwest::Client::builder()
+            .timeout(timeout)
+            .build()
+            .expect("Failed to create HTTP client");
+
+        let retry_policy = ExponentialBackoff::builder().build_with_max_retries(3);
+
+        let client = ClientBuilder::new(reqwest_client)
+            .with(RetryTransientMiddleware::new_with_policy(retry_policy))
+            .build();
+
+        Self { client }
+    }
+
+    async fn post_json<T: Serialize + ?Sized>(
+        &self,
+        url: &str,
+        body: &T,
+    ) -> std::result::Result<reqwest::Response, reqwest_middleware::Error> {
+        self.client.post(url).json(body).send().await
+    }
+}
+
 pub struct SorobanRpcClient {
-    config: SorobanConfig,
-    http_client: reqwest::Client,
+    rpc_urls: Vec<String>,
+    http_client: SorobanClient,
 }
 
 impl SorobanRpcClient {
     pub fn new(config: SorobanConfig) -> Self {
         Self {
-            config,
-            http_client: reqwest::Client::builder()
-                .timeout(Duration::from_secs(30))
-                .build()
-                .expect("Failed to create HTTP client"),
+            rpc_urls: config.rpc_endpoints(),
+            http_client: SorobanClient::new(Duration::from_secs(30)),
         }
+    }
+
+    fn track_failover(&self, from_index: usize, reason: &str) {
+        if from_index + 1 >= self.rpc_urls.len() {
+            return;
+        }
+
+        let from = &self.rpc_urls[from_index];
+        let to = &self.rpc_urls[from_index + 1];
+
+        counter!("soroban_rpc_failovers_total").increment(1);
+        warn!(
+            from_rpc_url = %from,
+            to_rpc_url = %to,
+            reason = %reason,
+            "Failing over Soroban RPC endpoint"
+        );
     }
 
     pub async fn call<P, R>(&self, method: &str, params: P) -> Result<R>
@@ -94,32 +141,84 @@ impl SorobanRpcClient {
             params,
         };
 
-        debug!("Soroban RPC call: {} with params: {:?}", method, serde_json::to_string(&request).unwrap_or_default());
+        debug!(
+            "Soroban RPC call: {} with params: {:?}",
+            method,
+            serde_json::to_string(&request).unwrap_or_default()
+        );
 
-        let response = self.http_client
-            .post(&self.config.rpc_url)
-            .json(&request)
-            .send()
-            .await
-            .map_err(|e| NetworkError::Connection(format!("Failed to send Soroban RPC request: {}", e)))?;
+        let mut last_error: Option<NetworkError> = None;
 
-        if !response.status().is_success() {
-            let status = response.status();
-            let text = response.text().await.unwrap_or_default();
-            error!("Soroban RPC HTTP error: {} - {}", status, text);
-            return Err(NetworkError::SorobanRpc(format!("HTTP error {}: {}", status, text)));
+        for (index, rpc_url) in self.rpc_urls.iter().enumerate() {
+            let response = match self.http_client.post_json(rpc_url, &request).await {
+                Ok(response) => response,
+                Err(e) => {
+                    let err = NetworkError::Connection(format!(
+                        "Failed to send Soroban RPC request to {}: {}",
+                        rpc_url, e
+                    ));
+
+                    if index + 1 < self.rpc_urls.len() {
+                        self.track_failover(index, "request_error");
+                        last_error = Some(err);
+                        continue;
+                    }
+
+                    return Err(err);
+                }
+            };
+
+            if response.status() == StatusCode::SERVICE_UNAVAILABLE
+                && index + 1 < self.rpc_urls.len()
+            {
+                let text = response.text().await.unwrap_or_default();
+                warn!(
+                    rpc_url = %rpc_url,
+                    status = %StatusCode::SERVICE_UNAVAILABLE,
+                    body = %text,
+                    "Soroban RPC endpoint unavailable"
+                );
+                self.track_failover(index, "http_503");
+                last_error = Some(NetworkError::SorobanRpc(format!(
+                    "HTTP error {} from {}: {}",
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    rpc_url,
+                    text
+                )));
+                continue;
+            }
+
+            if !response.status().is_success() {
+                let status = response.status();
+                let text = response.text().await.unwrap_or_default();
+                error!("Soroban RPC HTTP error: {} - {}", status, text);
+                return Err(NetworkError::SorobanRpc(format!(
+                    "HTTP error {}: {}",
+                    status, text
+                )));
+            }
+
+            let json_response: JsonRpcResponse<R> = response
+                .json()
+                .await
+                .map_err(|e| NetworkError::Serialization(e.into()))?;
+
+            if let Some(error) = json_response.error {
+                error!("Soroban RPC error {}: {}", error.code, error.message);
+                return Err(NetworkError::SorobanRpc(format!(
+                    "RPC error {}: {}",
+                    error.code, error.message
+                )));
+            }
+
+            return json_response.result.ok_or_else(|| {
+                NetworkError::SorobanRpc("Empty result in Soroban RPC response".to_string())
+            });
         }
 
-        let json_response: JsonRpcResponse<R> = response.json()
-            .await
-            .map_err(|e| NetworkError::Serialization(e.into()))?;
-
-        if let Some(error) = json_response.error {
-            error!("Soroban RPC error {}: {}", error.code, error.message);
-            return Err(NetworkError::SorobanRpc(format!("RPC error {}: {}", error.code, error.message)));
-        }
-
-        json_response.result.ok_or_else(|| NetworkError::SorobanRpc("Empty result in Soroban RPC response".to_string()))
+        Err(last_error.unwrap_or_else(|| {
+            NetworkError::SorobanRpc("No Soroban RPC endpoints available".to_string())
+        }))
     }
 
     pub async fn get_health(&self) -> Result<HealthResponse> {
@@ -128,19 +227,103 @@ impl SorobanRpcClient {
 
     pub async fn get_transaction(&self, hash: &str) -> Result<GetTransactionResponse> {
         #[derive(Serialize)]
-        struct Params { hash: String }
-        self.call("getTransaction", Params { hash: hash.to_string() }).await
+        struct Params {
+            hash: String,
+        }
+        self.call(
+            "getTransaction",
+            Params {
+                hash: hash.to_string(),
+            },
+        )
+        .await
     }
 
-    pub async fn simulate_transaction(&self, transaction_xdr: &str) -> Result<SimulateTransactionResponse> {
+    pub async fn simulate_transaction(
+        &self,
+        transaction_xdr: &str,
+    ) -> Result<SimulateTransactionResponse> {
         #[derive(Serialize)]
-        struct Params { transaction: String }
-        self.call("simulateTransaction", Params { transaction: transaction_xdr.to_string() }).await
+        struct Params {
+            transaction: String,
+        }
+        self.call(
+            "simulateTransaction",
+            Params {
+                transaction: transaction_xdr.to_string(),
+            },
+        )
+        .await
     }
 
     pub async fn send_transaction(&self, transaction_xdr: &str) -> Result<SendTransactionResponse> {
         #[derive(Serialize)]
-        struct Params { transaction: String }
-        self.call("sendTransaction", Params { transaction: transaction_xdr.to_string() }).await
+        struct Params {
+            transaction: String,
+        }
+        self.call(
+            "sendTransaction",
+            Params {
+                transaction: transaction_xdr.to_string(),
+            },
+        )
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::StatusCode as AxumStatusCode;
+    use axum::{routing::post, Json, Router};
+    use serde_json::json;
+    use tokio::net::TcpListener;
+
+    async fn spawn_test_server(app: Router) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        format!("http://{}", address)
+    }
+
+    #[tokio::test]
+    async fn falls_back_to_secondary_rpc_on_503() {
+        let primary_url = spawn_test_server(Router::new().route(
+            "/",
+            post(|| async { (AxumStatusCode::SERVICE_UNAVAILABLE, "service unavailable") }),
+        ))
+        .await;
+
+        let secondary_url = spawn_test_server(Router::new().route(
+            "/",
+            post(|| async {
+                Json(json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {
+                        "status": "healthy"
+                    }
+                }))
+            }),
+        ))
+        .await;
+
+        let config = SorobanConfig {
+            rpc_url: primary_url,
+            rpc_urls: vec![secondary_url],
+            ..SorobanConfig::default()
+        };
+
+        let client = SorobanRpcClient::new(config);
+        let health = client
+            .get_health()
+            .await
+            .expect("health check should succeed");
+
+        assert_eq!(health.status, "healthy");
     }
 }

--- a/network-node/tests/soroban_integration.rs
+++ b/network-node/tests/soroban_integration.rs
@@ -31,7 +31,7 @@ async fn test_soroban_simulate_read_only() {
     // Example: A simple read-only simulation for a known contract on Testnet
     // If you don't have a specific contract, we use a placeholder or simulate a failure
     let contract_id = "CCDRM2F5H7..."; // Placeholder
-    
+
     // In a real integration test, we would build a real InvokeHostFunction XDR here
     let dummy_tx_xdr = "AAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 


### PR DESCRIPTION

Closes #99

### Issue Summary

Soroban RPC communication used a single endpoint and raw HTTP calls, creating a single point of failure and weak handling for transient outages.


### Root Cause

- Soroban RPC configuration supported only one URL
- `SorobanRpcClient` had no middleware-based retry/backoff
- `EventIndexer` bypassed `SorobanRpcClient` and used its own direct RPC call path


### Fix Implemented

- Added Soroban fallback endpoint support with `rpc_urls` while preserving existing `rpc_url` compatibility
- Introduced `SorobanClient` wrapper around `reqwest` using `reqwest-middleware` and `reqwest-retry` exponential backoff
- Implemented failover to secondary RPC endpoint when primary returns HTTP `503`
- Added `soroban_rpc_failovers_total` metric to track failovers
- Updated `EventIndexer` to call `getEvents` through `SorobanRpcClient` so indexing uses the same retry/fallback behavior
- Added a unit test validating `503` failover to a secondary endpoint


### Testing Performed

- Added and reviewed targeted unit test for `503` failover behavior

Closes #99