### PR TITLE
Feature/mtls enforce

### DIFF
--- a/docs/MTLS_IMPLEMENTATION.md
+++ b/docs/MTLS_IMPLEMENTATION.md
@@ -1,0 +1,85 @@
+# mTLS Implementation and Operator Guide
+
+This document explains the mutual TLS (mTLS) enforcement added in branch `feature/mtls-enforce`, environment variables to configure it, verification steps, and CA rotation guidance.
+
+## Summary of changes
+
+- gRPC server (`network-node/src/grpc/server.rs`) now configures TLS using `rustls` and will require client certificates when `TLS_CLIENT_CA_PATH` is provided and `TLS_REQUIRE_CLIENT_AUTH=true`.
+- HTTP server (`network-node/src/enhanced_server.rs`) now performs transport-level TLS handshakes using `tokio-rustls`. Failed TLS handshakes are dropped and logged before any application parsing occurs.
+- `scripts/rotate_ca.sh` is present and can fetch a new CA bundle and atomically replace the local CA file. Use it to automate CA rotation.
+- New dependencies added to `network-node/Cargo.toml`: `rustls`, `tokio-rustls`, `tonic-rustls`, `rustls-pemfile`, `tokio-stream`, `tokio-stream`.
+
+## Environment variables
+
+- `TLS_CERT_PATH` - path to the PEM file with the server certificate chain (one or more `BEGIN CERTIFICATE` entries).
+- `TLS_KEY_PATH` - path to the PEM file containing the server private key (PKCS8 or RSA PEM supported).
+- `TLS_CLIENT_CA_PATH` - optional path to a PEM file containing one or more CA certificates used to validate client certificates.
+- `TLS_REQUIRE_CLIENT_AUTH` - `true`/`false`. When true and `TLS_CLIENT_CA_PATH` is set, the server requires client certificates (mTLS). Defaults to `true` when unspecified.
+
+## Behavioral guarantees
+
+- TLS negotiation happens at the transport layer. Any connection that fails the TLS handshake (including missing or invalid client certs when required) is dropped immediately and does not reach application-layer parsing.
+- When `TLS_CLIENT_CA_PATH` is omitted, the server falls back to one-way TLS (server-only cert).
+- When `TLS_REQUIRE_CLIENT_AUTH=false` but `TLS_CLIENT_CA_PATH` is provided, the server will accept connections without client certs but will still validate any presented client certs against the provided CA.
+
+## Operator steps: running locally
+
+1. Install Rust toolchain and dependencies (if not already):
+
+```bash
+# Install rustup then toolchain
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+rustup default stable
+
+cd network-node
+cargo build -p axionvera-network-node
+```
+
+2. Start the node with mTLS enabled (example):
+
+```bash
+TLS_CERT_PATH=/path/to/server.cert.pem \
+TLS_KEY_PATH=/path/to/server.key.pem \
+TLS_CLIENT_CA_PATH=/path/to/ca.cert.pem \
+TLS_REQUIRE_CLIENT_AUTH=true \
+cargo run -p axionvera-network-node
+```
+
+3. Verify behavior:
+
+- Try to connect without a client certificate (e.g., `curl` without client cert for HTTP or a gRPC client without cert). The connection should fail at TLS handshake.
+- Connect with a client certificate signed by the CA in `TLS_CLIENT_CA_PATH`. Connection should succeed.
+
+## CA rotation
+
+There is an operator helper script at `scripts/rotate_ca.sh` which will fetch a new CA bundle and atomically replace the destination file. Example usage:
+
+```bash
+# Fetch new CA bundle and replace local file
+scripts/rotate_ca.sh https://example.com/new-ca.pem /etc/axionvera/ca.cert.pem "systemctl restart axionvera-node"
+```
+
+Notes:
+- Use an orchestration step or systemd unit that restarts the service gracefully after CA rotation.
+- The script performs a basic validation that the fetched file contains a `BEGIN CERTIFICATE` header before replacing.
+
+## Testing & CI suggestions
+
+- Add integration tests that spawn the server in a test harness with temporary certs and exercise:
+  - Successful handshake with valid client cert
+  - Failed handshake when client cert absent or invalid
+  - Behavior when `TLS_REQUIRE_CLIENT_AUTH=false`
+
+- Add a CI job that builds `network-node` and runs the TLS integration tests.
+
+## Notes / Limitations
+
+- I could not run `cargo build` or execute tests in this environment (Rust toolchain not available here). Please run `cargo build` and paste any CI/build errors here and I will fix them.
+- There is no separate inbound P2P validator TCP listener implemented; if you operate a dedicated validator listener, I can integrate the same rustls handshake pattern for it.
+
+## Next actions I can take for you
+
+- Add integration tests for TLS handshake behavior.
+- Integrate mTLS into any other TCP listeners you specify (e.g., a P2P inbound listener).
+- Prepare a PR description and open a draft PR (if you provide remote access or push permissions), or prepare a ready-to-open PR file you can paste into GitHub.
+

--- a/docs/MTLS_ROTATION.md
+++ b/docs/MTLS_ROTATION.md
@@ -1,0 +1,14 @@
+**mTLS CA Rotation**
+- **Purpose**: Explain how to rotate the client CA used to validate mTLS client certificates for validator nodes.
+
+- **Preferred workflow**:
+  - Host the new CA PEM at a secure URL (internal storage for operator use).
+  - Run `scripts/rotate_ca.sh <CA_URL> /etc/axionvera/mtls/clients_ca.pem "systemctl restart axionvera-node"` on the node, or use the PowerShell script on Windows.
+
+- **Atomic update**: The scripts replace the file atomically to avoid partial reads by the server.
+
+- **Automatic restart**: Provide a restart command to the script to trigger a service restart (or use `systemctl reload`/SIGHUP if supported). If you run inside containers, use `docker restart <container>` or restart the pod.
+
+- **Notes about runtime reload**:
+  - The current `GrpcServer` config loads TLS settings at startup. After rotation the service must be restarted to pick up the new CA bundle, or your orchestration can replace the pod/container.
+  - Implementation of dynamic in-process TLS reloading is possible but more invasive; open an issue/PR if you want an in-process hot-reload.

--- a/network-node/Cargo.toml
+++ b/network-node/Cargo.toml
@@ -75,3 +75,4 @@ tonic-build = "0.11"
 [dev-dependencies]
 tempfile = "3.0"
 mockall = "0.11"
+rcgen = "0.9"

--- a/network-node/Cargo.toml
+++ b/network-node/Cargo.toml
@@ -33,6 +33,10 @@ metrics-exporter-prometheus = "0.12"
 prometheus = "0.13"
 redis = { version = "0.23", features = ["tokio-comp"] }
 tonic = { version = "0.11", features = ["transport", "prost", "gzip"] }
+rustls = { version = "0.21", package = "rustls" }
+tokio-rustls = "0.23"
+tonic-rustls = "0.6"
+rustls-pemfile = "1.0"
 prost = "0.12"
 prost-types = "0.12"
 tonic-web = "0.11"

--- a/network-node/Cargo.toml
+++ b/network-node/Cargo.toml
@@ -37,6 +37,7 @@ rustls = { version = "0.21", package = "rustls" }
 tokio-rustls = "0.23"
 tonic-rustls = "0.6"
 rustls-pemfile = "1.0"
+tokio-stream = "0.1"
 prost = "0.12"
 prost-types = "0.12"
 tonic-web = "0.11"

--- a/network-node/src/config.rs
+++ b/network-node/src/config.rs
@@ -81,6 +81,10 @@ pub struct NetworkConfig {
     pub bootstrap_peer: Option<String>,
     pub tls_cert_path: Option<String>,
     pub tls_key_path: Option<String>,
+    /// Optional path to a PEM file containing trusted client CA certificates
+    pub tls_client_ca_path: Option<String>,
+    /// Whether to require client certificates (mTLS). Defaults to true when a client CA is provided.
+    pub tls_require_client_auth: bool,
     pub enable_gateway: bool,
     pub enable_reflection: bool,
     pub node_id: String,
@@ -215,6 +219,10 @@ impl NetworkConfig {
             bootstrap_peer: std::env::var("BOOTSTRAP_PEER").ok(),
             tls_cert_path: std::env::var("TLS_CERT_PATH").ok(),
             tls_key_path: std::env::var("TLS_KEY_PATH").ok(),
+            tls_client_ca_path: std::env::var("TLS_CLIENT_CA_PATH").ok(),
+            tls_require_client_auth: std::env::var("TLS_REQUIRE_CLIENT_AUTH").ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(true),
             enable_gateway: std::env::var("ENABLE_GATEWAY").unwrap_or_else(|_| "true".to_string()).parse().unwrap_or(true),
             enable_reflection: std::env::var("ENABLE_REFLECTION").unwrap_or_else(|_| "true".to_string()).parse().unwrap_or(true),
             node_id,

--- a/network-node/src/enhanced_server.rs
+++ b/network-node/src/enhanced_server.rs
@@ -5,6 +5,13 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
+use tokio_rustls::rustls::{Certificate, PrivateKey, RootCertStore, ServerConfig as RustlsServerConfig, AllowAnyAuthenticatedClient};
+use tokio_rustls::TlsAcceptor;
+use std::io::Cursor;
+use rustls_pemfile::{certs, read_one, Item};
+use tokio_stream::wrappers::TcpListenerStream;
+use futures_util::StreamExt;
+use hyper::server::accept::from_stream;
 use serde_json::{json, Value};
 use std::sync::Arc;
 use std::time::Duration;
@@ -150,7 +157,7 @@ impl EnhancedHttpServer {
             .parse()
             .map_err(|e| NetworkError::Config(format!("Invalid bind address: {}", e)))?;
 
-        // Start the server
+        // Start the server (with optional TLS / mTLS)
         let handle = tokio::spawn(async move {
             let listener = tokio::net::TcpListener::bind(addr)
                 .await
@@ -158,6 +165,109 @@ impl EnhancedHttpServer {
 
             info!("HTTP server listening on {}", addr);
 
+            // If TLS certs are provided, wrap incoming connections with a TLS acceptor
+            if let (Some(cert_path), Some(key_path)) = (&self.config.tls_cert_path, &self.config.tls_key_path) {
+                // Read certs and keys
+                let cert_pem = std::fs::read(cert_path)
+                    .map_err(|e| NetworkError::Config(format!("Failed to read TLS certificate: {}", e)))?;
+                let key_pem = std::fs::read(key_path)
+                    .map_err(|e| NetworkError::Config(format!("Failed to read TLS private key: {}", e)))?;
+
+                // Parse server certs
+                let mut cert_cursor = Cursor::new(&cert_pem);
+                let server_certs = certs(&mut cert_cursor)
+                    .map_err(|_| NetworkError::Config("Failed to parse server cert PEM".to_string()))?;
+                if server_certs.is_empty() {
+                    return Err(NetworkError::Config("No server certificates found in TLS cert file".to_string()));
+                }
+
+                // Parse private key
+                let mut key_cursor = Cursor::new(&key_pem);
+                let mut keys = Vec::new();
+                loop {
+                    match read_one(&mut key_cursor).map_err(|_| NetworkError::Config("Failed to parse TLS private key PEM".to_string()))? {
+                        Some(Item::PKCS8Key(key)) => { keys.push(key); }
+                        Some(Item::RSAKey(key)) => { keys.push(key); }
+                        Some(_) => {}
+                        None => break,
+                    }
+                }
+                if keys.is_empty() {
+                    return Err(NetworkError::Config("No private keys found in TLS key file".to_string()));
+                }
+
+                let der_certs = server_certs.into_iter().map(Certificate).collect::<Vec<_>>();
+                let der_key = PrivateKey(keys.remove(0));
+
+                // Build root store if client CA provided
+                let mut rustls_cfg = if let Some(client_ca_path) = &self.config.tls_client_ca_path {
+                    let ca_pem = std::fs::read(client_ca_path)
+                        .map_err(|e| NetworkError::Config(format!("Failed to read TLS client CA file: {}", e)))?;
+
+                    let mut roots = RootCertStore::empty();
+                    let mut cursor = Cursor::new(&ca_pem);
+                    let parsed = certs(&mut cursor)
+                        .map_err(|_| NetworkError::Config("Failed to parse client CA PEM".to_string()))?;
+                    if parsed.is_empty() {
+                        return Err(NetworkError::Config("No CA certificates found in tls_client_ca_path".to_string()));
+                    }
+                    for cert in parsed { roots.add(&Certificate(cert)).map_err(|e| NetworkError::Config(format!("Failed to add CA cert to root store: {}", e)))?; }
+
+                    if self.config.tls_require_client_auth {
+                        RustlsServerConfig::builder()
+                            .with_safe_defaults()
+                            .with_client_cert_verifier(AllowAnyAuthenticatedClient::new(roots))
+                            .with_single_cert(der_certs.clone(), der_key.clone())
+                            .map_err(|e| NetworkError::Config(format!("Failed to create rustls server config: {}", e)))?
+                    } else {
+                        RustlsServerConfig::builder()
+                            .with_safe_defaults()
+                            .with_no_client_auth()
+                            .with_single_cert(der_certs.clone(), der_key.clone())
+                            .map_err(|e| NetworkError::Config(format!("Failed to create rustls server config: {}", e)))?
+                    }
+                } else {
+                    // No client CA: one-way TLS
+                    RustlsServerConfig::builder()
+                        .with_safe_defaults()
+                        .with_no_client_auth()
+                        .with_single_cert(der_certs.clone(), der_key.clone())
+                        .map_err(|e| NetworkError::Config(format!("Failed to create rustls server config: {}", e)))?
+                };
+
+                let acceptor = TlsAcceptor::from(std::sync::Arc::new(rustls_cfg));
+                let acceptor = std::sync::Arc::new(acceptor);
+
+                // Build incoming stream that performs TLS handshake per-connection.
+                let incoming = TcpListenerStream::new(listener)
+                    .filter_map(move |tcp_res| {
+                        let acceptor = acceptor.clone();
+                        async move {
+                            match tcp_res {
+                                Ok(stream) => match acceptor.accept(stream).await {
+                                    Ok(tls_stream) => Some(Ok::<_, std::io::Error>(tls_stream)),
+                                    Err(e) => {
+                                        tracing::warn!("TLS handshake failed: {}", e);
+                                        // Drop connection by returning None
+                                        None
+                                    }
+                                },
+                                Err(e) => Some(Err(e)),
+                            }
+                        }
+                    });
+
+                let server = hyper::Server::builder(from_stream(incoming))
+                    .serve(app.into_make_service())
+                    .with_graceful_shutdown(async {
+                        shutdown_rx.await.ok();
+                        info!("HTTP server shutdown signal received");
+                    });
+
+                return server.await.map_err(|e| NetworkError::Server(format!("HTTP server error: {}", e)));
+            }
+
+            // No TLS configured: plain TCP
             axum::serve(listener, app)
                 .with_graceful_shutdown(async {
                     shutdown_rx.await.ok();

--- a/network-node/src/grpc/server.rs
+++ b/network-node/src/grpc/server.rs
@@ -5,6 +5,10 @@ use tokio::sync::RwLock;
 use tonic::metadata::MetadataMap;
 use tonic::service::{interceptor, Interceptor};
 use tonic::transport::{Identity, Server, ServerTlsConfig};
+use tokio_rustls::rustls::{Certificate, PrivateKey, RootCertStore, ServerConfig as RustlsServerConfig, AllowAnyAuthenticatedClient};
+use tonic_rustls::server::TlsConfigExt;
+use std::io::Cursor;
+use rustls_pemfile::{certs, read_one, Item};
 use tonic::{Request, Status};
 use tracing::{info, error, warn};
 
@@ -240,21 +244,99 @@ impl GrpcServer {
             )
         );
 
-        // Configure TLS if certificates are provided
+        // Configure TLS (with optional mTLS) if certificates are provided
         if let (Some(cert_path), Some(key_path)) = (&self.config.tls_cert_path, &self.config.tls_key_path) {
             info!("Configuring TLS for gRPC server");
-            
-            let cert = std::fs::read_to_string(cert_path)
+
+            // Read server cert and key as PEM bytes and parse into DER for rustls
+            let cert_pem = std::fs::read(cert_path)
                 .map_err(|e| NetworkError::Config(format!("Failed to read TLS certificate: {}", e)))?;
-            let key = std::fs::read_to_string(key_path)
+            let key_pem = std::fs::read(key_path)
                 .map_err(|e| NetworkError::Config(format!("Failed to read TLS private key: {}", e)))?;
 
-            let identity = Identity::from_pem(cert, key);
-            let tls_config = ServerTlsConfig::new()
-                .identity(identity);
+            // Build identity for tonic by converting to strings (preserve previous behavior)
+            let cert_str = String::from_utf8(cert_pem.clone())
+                .map_err(|e| NetworkError::Config(format!("Invalid cert PEM encoding: {}", e)))?;
+            let key_str = String::from_utf8(key_pem.clone())
+                .map_err(|e| NetworkError::Config(format!("Invalid key PEM encoding: {}", e)))?;
 
-            server = server.tls_config(tls_config)
-                .map_err(|e| NetworkError::Config(format!("Failed to configure TLS: {}", e)))?;
+            let identity = Identity::from_pem(cert_str, key_str);
+
+            // If a client CA is provided, configure rustls to require client authentication
+            if let Some(client_ca_path) = &self.config.tls_client_ca_path {
+                info!("Configuring mTLS: requiring client certificates");
+
+                let ca_pem = std::fs::read(client_ca_path)
+                    .map_err(|e| NetworkError::Config(format!("Failed to read TLS client CA file: {}", e)))?;
+
+                // Parse CA certs and populate a RootCertStore using rustls-pemfile
+                let mut roots = RootCertStore::empty();
+                let mut cursor = Cursor::new(&ca_pem);
+                let parsed = certs(&mut cursor)
+                    .map_err(|_| NetworkError::Config("Failed to parse client CA PEM".to_string()))?;
+
+                if parsed.is_empty() {
+                    return Err(NetworkError::Config("No CA certificates found in tls_client_ca_path".to_string()));
+                }
+
+                for cert in parsed {
+                    roots.add(&Certificate(cert)).map_err(|e| NetworkError::Config(format!("Failed to add CA cert to root store: {}", e)))?;
+                }
+
+                // Parse server cert PEM to DER vec
+                let mut cert_cursor = Cursor::new(&cert_pem);
+                let server_certs = certs(&mut cert_cursor)
+                    .map_err(|_| NetworkError::Config("Failed to parse server cert PEM".to_string()))?;
+
+                if server_certs.is_empty() {
+                    return Err(NetworkError::Config("No server certificates found in TLS cert file".to_string()));
+                }
+
+                // Parse private key PEM (support pkcs8 and rsa)
+                let mut key_cursor = Cursor::new(&key_pem);
+                let mut keys = Vec::new();
+                loop {
+                    match read_one(&mut key_cursor).map_err(|_| NetworkError::Config("Failed to parse TLS private key PEM".to_string()))? {
+                        Some(Item::PKCS8Key(key)) => { keys.push(key); }
+                        Some(Item::RSAKey(key)) => { keys.push(key); }
+                        Some(_) => {}
+                        None => break,
+                    }
+                }
+
+                if keys.is_empty() {
+                    return Err(NetworkError::Config("No private keys found in TLS key file".to_string()));
+                }
+
+                let der_certs = server_certs.into_iter().map(Certificate).collect::<Vec<_>>();
+                let der_key = PrivateKey(keys.remove(0));
+
+                let mut rustls_cfg = RustlsServerConfig::builder()
+                    .with_safe_defaults()
+                    .with_client_cert_verifier(AllowAnyAuthenticatedClient::new(roots))
+                    .with_single_cert(der_certs.clone(), der_key.clone())
+                    .map_err(|e| NetworkError::Config(format!("Failed to create rustls server config: {}", e)))?;
+
+                // If configured to not require client auth, switch to NoClientAuth
+                if !self.config.tls_require_client_auth {
+                    rustls_cfg = RustlsServerConfig::builder()
+                        .with_safe_defaults()
+                        .with_no_client_auth()
+                        .with_single_cert(der_certs.clone(), der_key.clone())
+                        .map_err(|e| NetworkError::Config(format!("Failed to create rustls server config: {}", e)))?;
+                }
+
+                // Convert rustls config into a tonic ServerTlsConfig via tonic-rustls helper
+                let tls_config = ServerTlsConfig::new().rustls_server_config(Arc::new(rustls_cfg));
+
+                server = server.tls_config(tls_config)
+                    .map_err(|e| NetworkError::Config(format!("Failed to configure TLS: {}", e)))?;
+            } else {
+                // No client CA provided: use one-way TLS with existing Identity path
+                let tls_config = ServerTlsConfig::new().identity(identity);
+                server = server.tls_config(tls_config)
+                    .map_err(|e| NetworkError::Config(format!("Failed to configure TLS: {}", e)))?;
+            }
         }
 
         // Add reflection service for development

--- a/network-node/src/server.rs
+++ b/network-node/src/server.rs
@@ -195,8 +195,19 @@ impl GrpcServer {
                 .map_err(|e| NetworkError::Config(format!("Failed to read TLS private key: {}", e)))?;
 
             let identity = Identity::from_pem(cert, key);
-            let tls_config = ServerTlsConfig::new()
-                .identity(identity);
+            let mut tls_config = ServerTlsConfig::new().identity(identity);
+
+            // Configure mutual TLS (mTLS) if a client CA is provided
+            if let Some(ca_path) = &self.config.tls_client_ca_path {
+                info!("Configuring client CA for mTLS: {}", ca_path);
+                let ca_pem = std::fs::read_to_string(ca_path)
+                    .map_err(|e| NetworkError::Config(format!("Failed to read client CA file: {}", e)))?;
+                let ca_cert = Certificate::from_pem(ca_pem);
+                tls_config = tls_config.client_ca_root(ca_cert);
+            } else if self.config.tls_require_client_auth {
+                // If operator explicitly requires client auth but no CA provided, fail fast to avoid insecure startup
+                return Err(NetworkError::Config("TLS client authentication is required but no TLS_CLIENT_CA_PATH is configured".to_string()));
+            }
 
             server = server.tls_config(tls_config)
                 .map_err(|e| NetworkError::Config(format!("Failed to configure TLS: {}", e)))?;

--- a/network-node/src/tls_utils.rs
+++ b/network-node/src/tls_utils.rs
@@ -1,0 +1,67 @@
+use std::io::Cursor;
+use rustls_pemfile::{certs, read_one, Item};
+use tokio_rustls::rustls::{Certificate, PrivateKey, RootCertStore, ServerConfig as RustlsServerConfig, AllowAnyAuthenticatedClient};
+
+pub fn build_rustls_server_config(
+    cert_pem: &[u8],
+    key_pem: &[u8],
+    client_ca_pem: Option<&[u8]>,
+    require_client_auth: bool,
+) -> Result<RustlsServerConfig, String> {
+    // Parse server certs
+    let mut cert_cursor = Cursor::new(cert_pem);
+    let server_certs = certs(&mut cert_cursor).map_err(|_| "Failed to parse server cert PEM".to_string())?;
+    if server_certs.is_empty() {
+        return Err("No server certificates found in TLS cert data".to_string());
+    }
+
+    // Parse private key
+    let mut key_cursor = Cursor::new(key_pem);
+    let mut keys = Vec::new();
+    loop {
+        match read_one(&mut key_cursor).map_err(|_| "Failed to parse TLS private key PEM".to_string())? {
+            Some(Item::PKCS8Key(key)) => { keys.push(key); }
+            Some(Item::RSAKey(key)) => { keys.push(key); }
+            Some(_) => {}
+            None => break,
+        }
+    }
+    if keys.is_empty() {
+        return Err("No private keys found in TLS key data".to_string());
+    }
+
+    let der_certs = server_certs.into_iter().map(Certificate).collect::<Vec<_>>();
+    let der_key = PrivateKey(keys.remove(0));
+
+    let cfg = if let Some(ca_pem) = client_ca_pem {
+        let mut roots = RootCertStore::empty();
+        let mut cursor = Cursor::new(ca_pem);
+        let parsed = certs(&mut cursor).map_err(|_| "Failed to parse client CA PEM".to_string())?;
+        if parsed.is_empty() {
+            return Err("No CA certificates found in client CA PEM".to_string());
+        }
+        for cert in parsed { roots.add(&Certificate(cert)).map_err(|e| format!("Failed to add CA cert: {}", e))?; }
+
+        if require_client_auth {
+            RustlsServerConfig::builder()
+                .with_safe_defaults()
+                .with_client_cert_verifier(AllowAnyAuthenticatedClient::new(roots))
+                .with_single_cert(der_certs, der_key)
+                .map_err(|e| format!("Failed to create rustls server config: {}", e))?
+        } else {
+            RustlsServerConfig::builder()
+                .with_safe_defaults()
+                .with_no_client_auth()
+                .with_single_cert(der_certs, der_key)
+                .map_err(|e| format!("Failed to create rustls server config: {}", e))?
+        }
+    } else {
+        RustlsServerConfig::builder()
+            .with_safe_defaults()
+            .with_no_client_auth()
+            .with_single_cert(der_certs, der_key)
+            .map_err(|e| format!("Failed to create rustls server config: {}", e))?
+    };
+
+    Ok(cfg)
+}

--- a/network-node/tests/tls_handshake.rs
+++ b/network-node/tests/tls_handshake.rs
@@ -1,0 +1,76 @@
+use rcgen::{CertificateParams, DistinguishedName, DnType, IsCa, BasicConstraints};
+use tokio::net::TcpListener;
+use tokio_rustls::TlsAcceptor;
+use tokio_rustls::rustls::{ClientConfig, RootCertStore, Certificate as RCert};
+use tokio_rustls::TlsConnector;
+use tokio::io::{AsyncWriteExt};
+use std::sync::Arc;
+use axionvera_network_node::tls_utils::build_rustls_server_config;
+
+#[tokio::test]
+async fn server_rejects_client_without_cert_when_mtls_required() {
+    // Create CA
+    let mut ca_params = CertificateParams::new(vec![]);
+    ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    ca_params.distinguished_name = DistinguishedName::new();
+    ca_params.distinguished_name.push(DnType::CommonName, "Test CA");
+    let ca_cert = rcgen::Certificate::from_params(ca_params).unwrap();
+
+    // Server cert signed by CA
+    let mut server_params = CertificateParams::new(vec!["localhost".to_string()]);
+    server_params.distinguished_name = DistinguishedName::new();
+    server_params.distinguished_name.push(DnType::CommonName, "localhost");
+    server_params.is_ca = IsCa::NoCa;
+    let server_cert = rcgen::Certificate::from_params(server_params).unwrap();
+    let server_cert_pem = server_cert.serialize_pem_with_signer(&ca_cert).unwrap();
+    let server_key_pem = server_cert.serialize_private_key_pem();
+    let ca_pem = ca_cert.serialize_pem().unwrap();
+
+    // Build rustls server config requiring client auth
+    let rustls_cfg = build_rustls_server_config(
+        server_cert_pem.as_bytes(),
+        server_key_pem.as_bytes(),
+        Some(ca_pem.as_bytes()),
+        true,
+    ).expect("build server config");
+
+    let acceptor = TlsAcceptor::from(Arc::new(rustls_cfg));
+
+    // Start listener
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    // Server task: accept and attempt TLS handshake
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        match acceptor.accept(stream).await {
+            Ok(mut s) => {
+                // If handshake unexpectedly succeeds, write marker
+                let _ = s.write_all(b"OK").await;
+            }
+            Err(_) => {
+                // Handshake failed; drop connection
+            }
+        }
+    });
+
+    // Client: build client config trusting CA, but provide no client cert
+    let mut root_store = RootCertStore::empty();
+    let ca_certs = rustls_pemfile::certs(&mut ca_pem.as_bytes()).unwrap();
+    for cert in ca_certs { root_store.add(&RCert(cert)).unwrap(); }
+
+    let client_cfg = ClientConfig::builder()
+        .with_safe_defaults()
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+
+    let connector = TlsConnector::from(Arc::new(client_cfg));
+    let stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+    let domain = rustls::ServerName::try_from("localhost").unwrap();
+
+    let res = connector.connect(domain, stream).await;
+
+    assert!(res.is_err(), "Handshake should fail when client cert is missing");
+
+    let _ = server.await;
+}

--- a/scripts/create_mtls_branch.sh
+++ b/scripts/create_mtls_branch.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Helper to create a feature branch for the mTLS enforcement changes and commit local modifications.
+BRANCH_NAME=${1:-feature/mtls-enforcement}
+set -euo pipefail
+if [ -n "$(git status --porcelain)" ]; then
+  echo "Working tree is dirty; please commit or stash changes before creating the branch." >&2
+  exit 1
+fi
+git checkout -b "$BRANCH_NAME"
+# Optionally stage and commit all changes
+if [ "$#" -ge 2 ] && [ "$2" = "--commit-all" ]; then
+  git add -A
+  git commit -m "feat: enforce mTLS, add CA rotation tooling"
+  echo "Committed changes on $BRANCH_NAME"
+else
+  echo "Created branch $BRANCH_NAME. Use --commit-all to commit current changes." 
+fi

--- a/scripts/rotate_ca.ps1
+++ b/scripts/rotate_ca.ps1
@@ -1,0 +1,25 @@
+Param(
+  [Parameter(Mandatory=$true)][string]$CaUrl,
+  [Parameter(Mandatory=$true)][string]$DestPath,
+  [string]$RestartCmd
+)
+$Temp = [System.IO.Path]::GetTempFileName()
+try {
+  Invoke-WebRequest -UseBasicParsing -Uri $CaUrl -OutFile $Temp
+  $content = Get-Content $Temp -Raw
+  if ($content -notmatch 'BEGIN CERTIFICATE') {
+    Write-Error "Fetched file does not look like a PEM certificate"
+    exit 3
+  }
+  $dir = Split-Path $DestPath -Parent
+  if (-not (Test-Path $dir)) { New-Item -ItemType Directory -Path $dir | Out-Null }
+  Move-Item -Force $Temp ($DestPath + ".tmp")
+  Move-Item -Force ($DestPath + ".tmp") $DestPath
+  Write-Output "Replaced CA at $DestPath"
+  if ($RestartCmd) {
+    Write-Output "Running restart command: $RestartCmd"
+    iex $RestartCmd
+  }
+} finally {
+  if (Test-Path $Temp) { Remove-Item $Temp -ErrorAction SilentlyContinue }
+}

--- a/scripts/rotate_ca.sh
+++ b/scripts/rotate_ca.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# rotate_ca.sh - Fetch a new client CA bundle, validate, atomically replace local CA, and optionally restart service.
+# Usage: rotate_ca.sh <url> <dest_path> [--restart-cmd "systemctl restart axionvera-node"]
+set -euo pipefail
+if [ "$#" -lt 2 ]; then
+  echo "Usage: $0 <ca_pem_url> <dest_path> [--restart-cmd \"command\"]"
+  exit 2
+fi
+CA_URL="$1"
+DEST_PATH="$2"
+RESTART_CMD=""
+if [ "$#" -ge 3 ]; then
+  RESTART_CMD="$3"
+fi
+TMPFILE=$(mktemp /tmp/ca_pem.XXXXXX)
+trap 'rm -f "$TMPFILE"' EXIT
+curl -fsSL "$CA_URL" -o "$TMPFILE"
+# Basic validation: check for PEM header
+if ! grep -q "BEGIN CERTIFICATE" "$TMPFILE"; then
+  echo "Fetched file does not look like a PEM certificate" >&2
+  exit 3
+fi
+# Atomically replace
+mkdir -p "$(dirname "$DEST_PATH")"
+chmod 644 "$TMPFILE"
+mv "$TMPFILE" "${DEST_PATH}.tmp"
+mv -f "${DEST_PATH}.tmp" "$DEST_PATH"
+echo "Replaced CA at $DEST_PATH"
+if [ -n "$RESTART_CMD" ]; then
+  echo "Running restart command: $RESTART_CMD"
+  eval "$RESTART_CMD"
+fi
+echo "CA rotation complete"


### PR DESCRIPTION
Summary

Enforces transport-level mutual TLS (mTLS) for the gRPC and HTTP listeners. When a client CA is configured, the server requires and validates client certificates at the TLS layer and drops connections that fail the TLS handshake before any application parsing.
Adds CA rotation helper and an integration test that verifies handshake rejection when client cert is missing.


closes #23