### PR TITLE
feat(vault-contract): add reward vesting functionality

### DIFF
--- a/contracts/vault-contract/src/errors.rs
+++ b/contracts/vault-contract/src/errors.rs
@@ -73,6 +73,13 @@ pub enum ArithmeticError {
     ZeroRewardIncrement,
 }
 
+/// Specific errors related to vesting.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum VestingError {
+    /// Thrown when a user tries to claim unvested rewards.
+    RewardsNotVested,
+}
+
 /// Specific errors related to authorization and security.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum AuthorizationError {
@@ -91,35 +98,6 @@ pub enum AuthorizationError {
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u32)]
 pub enum VaultError {
-    /// Error code 1: The vault has already been initialized.
-    AlreadyInitialized = 1,
-    /// Error code 2: The vault has not been initialized yet.
-    NotInitialized = 2,
-    /// Error code 3: The caller is not authorized for this operation.
-    Unauthorized = 3,
-    /// Error code 4: The provided amount is invalid (e.g., zero).
-    InvalidAmount = 4,
-    /// Error code 5: The user has insufficient balance for the operation.
-    InsufficientBalance = 5,
-    /// Error code 6: An arithmetic overflow or underflow occurred.
-    MathOverflow = 6,
-    /// Error code 7: No deposits are present to receive distributed rewards.
-    NoDeposits = 7,
-    /// Error code 8: The token configuration (deposit vs reward) is invalid.
-    InvalidTokenConfiguration = 8,
-    /// Error code 9: The contract has insufficient funds to fulfill a request.
-    InsufficientContractBalance = 9,
-    /// Error code 10: A negative amount was provided where prohibited.
-    NegativeAmount = 10,
-    /// Error code 11: The provided address is invalid.
-    InvalidAddress = 11,
-    /// Error code 12: Reward calculation failed due to mathematical error.
-    RewardCalculationFailed = 12,
-    /// Error code 13: A reentrant call was detected and blocked.
-    ReentrancyDetected = 13,
-    /// Error code 14: The internal state of the contract is invalid.
-    InvalidState = 14,
-    /// Error code 15: The reward increment would be zero (amount too small).
     /// Vault has already been initialized
     AlreadyInitialized = 1,
     /// Vault has not been initialized
@@ -150,6 +128,8 @@ pub enum VaultError {
     /// Reward distribution rounded down to zero
     ZeroRewardIncrement = 15,
     NoPendingAdmin = 16,
+    /// Rewards are not yet vested
+    RewardsNotVested = 17,
 }
 
 impl VaultError {
@@ -218,6 +198,10 @@ impl VaultError {
             Self::NoPendingAdmin => ErrorInfo {
                 category: ErrorCategory::State,
                 message: "no pending admin transfer exists",
+            },
+            Self::RewardsNotVested => ErrorInfo {
+                category: ErrorCategory::Validation,
+                message: "rewards are not yet vested",
             },
         }
     }
@@ -293,6 +277,14 @@ impl From<AuthorizationError> for VaultError {
             AuthorizationError::Unauthorized => Self::Unauthorized,
             AuthorizationError::ReentrancyDetected => Self::ReentrancyDetected,
             AuthorizationError::UpgradeFailed => Self::UpgradeFailed,
+        }
+    }
+}
+
+impl From<VestingError> for VaultError {
+    fn from(error: VestingError) -> Self {
+        match error {
+            VestingError::RewardsNotVested => Self::RewardsNotVested,
         }
     }
 }

--- a/contracts/vault-contract/src/events.rs
+++ b/contracts/vault-contract/src/events.rs
@@ -1,104 +1,15 @@
-//! Event definitions and emission helpers for the Vault contract.
-//!
-//! Events are used for off-chain monitoring, indexing, and front-end updates.
-//! Each event is identified by a specific symbol and carries relevant data.
-
-use soroban_sdk::{symbol_short, Address, Env, Symbol};
-
-/// Event topics for the vault contract.
-pub struct Topics;
-
-impl Topics {
-    /// Topic emitted when the contract is initialized.
-    pub const INITIALIZE: Symbol = symbol_short!("init");
-    /// Topic emitted when a user deposits tokens.
-    pub const DEPOSIT: Symbol = symbol_short!("deposit");
-    /// Topic emitted when a user withdraws tokens.
-    pub const WITHDRAW: Symbol = symbol_short!("withdraw");
-    /// Topic emitted when rewards are distributed by the admin.
-    pub const DISTRIBUTE: Symbol = symbol_short!("distrib");
-    /// Topic emitted when a user claims their accrued rewards.
-    pub const CLAIM: Symbol = symbol_short!("claim");
-}
-
-/// Emits an event indicating the contract has been successfully initialized.
-///
-/// # Arguments
-/// * `e` - The environment.
-/// * `admin` - The address set as the contract administrator.
-/// * `deposit_token` - The address of the accepted deposit token.
-/// * `reward_token` - The address of the distributed reward token.
-pub fn emit_initialize(e: &Env, admin: Address, deposit_token: Address, reward_token: Address) {
-    e.events().publish(
-        (Topics::INITIALIZE,),
-        (admin, deposit_token, reward_token),
-    );
-}
-
-/// Emits an event when a user makes a deposit.
-///
-/// # Arguments
-/// * `e` - The environment.
-/// * `user` - The address of the user who deposited.
-/// * `amount` - The amount of tokens deposited.
-/// * `new_balance` - The user's new total balance after the deposit.
-pub fn emit_deposit(e: &Env, user: Address, amount: i128, new_balance: i128) {
-    e.events().publish(
-        (Topics::DEPOSIT, user),
-        (amount, new_balance),
-    );
-}
-
-/// Emits an event when a user withdraws their stake.
-///
-/// # Arguments
-/// * `e` - The environment.
-/// * `user` - The address of the user who withdrew.
-/// * `amount` - The amount of tokens withdrawn.
-/// * `remaining_balance` - The user's remaining balance in the vault.
-pub fn emit_withdraw(e: &Env, user: Address, amount: i128, remaining_balance: i128) {
-    e.events().publish(
-        (Topics::WITHDRAW, user),
-        (amount, remaining_balance),
-    );
-}
-
-/// Emits an event when new rewards are distributed.
-///
-/// # Arguments
-/// * `e` - The environment.
-/// * `amount` - The total amount of reward tokens distributed.
-/// * `new_index` - The global reward index after the distribution.
-pub fn emit_distribute_rewards(e: &Env, amount: i128, new_index: i128) {
-    e.events().publish(
-        (Topics::DISTRIBUTE,),
-        (amount, new_index),
-    );
-}
-
-/// Emits an event when a user claims their accrued rewards.
-///
-/// # Arguments
-/// * `e` - The environment.
-/// * `user` - The address of the user who claimed rewards.
-/// * `amount` - The amount of reward tokens claimed.
-pub fn emit_claim_rewards(e: &Env, user: Address, amount: i128) {
-    e.events().publish(
-        (Topics::CLAIM, user),
-        (amount,),
 use soroban_sdk::{contracttype, symbol_short, Address, BytesN, Env, Symbol};
 
-/// Protocol identifier for all Axionvera Vault events (Topic 1)
 const PROTOCOL: Symbol = symbol_short!("AxionVault");
-
-/// Event action types (Topic 2)
 const ACT_INIT: Symbol = symbol_short!("Initialize");
 const ACT_DEPOSIT: Symbol = symbol_short!("Deposit");
 const ACT_WITHDRAW: Symbol = symbol_short!("Withdraw");
 const ACT_DISTRIBUTE: Symbol = symbol_short!("Distribute");
 const ACT_CLAIM: Symbol = symbol_short!("Claim");
+const EVT_ADMIN_PROPOSED: Symbol = symbol_short!("AdminProp");
+const EVT_ADMIN_ACCEPTED: Symbol = symbol_short!("AdminAcpt");
+const EVT_UPGRADE: Symbol = symbol_short!("Upgrade");
 
-/// Initialize event payload: contract setup with protocol parameters
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct InitializeEvent {
@@ -108,28 +19,23 @@ pub struct InitializeEvent {
     pub timestamp: u64,
 }
 
-/// Deposit event payload: user deposits tokens into vault
-/// Data payload contains user_address, amount, and timestamp.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DepositEvent {
-    pub user_address: Address,
+    pub user: Address,
     pub amount: i128,
     pub timestamp: u64,
 }
 
-/// Withdraw event payload: user withdraws tokens from vault
-/// Data payload contains user_address, amount, and timestamp.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct WithdrawEvent {
-    pub user_address: Address,
+    pub user: Address,
     pub amount: i128,
+    pub remaining_balance: i128,
     pub timestamp: u64,
 }
 
-/// Distribute event payload: admin distributes reward tokens
-/// Data payload contains caller address, amount distributed, and timestamp.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DistributeEvent {
@@ -138,23 +44,38 @@ pub struct DistributeEvent {
     pub timestamp: u64,
 }
 
-/// Claim event payload: user claims accrued rewards
-/// Data payload contains user_address, amount claimed, and timestamp.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ClaimEvent {
-    pub user_address: Address,
+    pub user: Address,
     pub amount: i128,
     pub timestamp: u64,
 }
 
-/// Emits a standardized Initialize event.
-///
-/// Topics:
-/// - Topic 1: "AxionVault" (protocol identifier)
-/// - Topic 2: "Initialize" (action)
-///
-/// Data payload contains admin, deposit_token, reward_token, and timestamp.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdminTransferProposedEvent {
+    pub current_admin: Address,
+    pub pending_admin: Address,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdminTransferAcceptedEvent {
+    pub previous_admin: Address,
+    pub new_admin: Address,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UpgradeEvent {
+    pub admin: Address,
+    pub new_wasm_hash: BytesN<32>,
+    pub timestamp: u64,
+}
+
 pub fn emit_initialize(e: &Env, admin: Address, deposit_token: Address, reward_token: Address) {
     e.events().publish(
         (PROTOCOL, ACT_INIT),
@@ -167,49 +88,29 @@ pub fn emit_initialize(e: &Env, admin: Address, deposit_token: Address, reward_t
     );
 }
 
-/// Emits a standardized Deposit event.
-///
-/// Topics:
-/// - Topic 1: "AxionVault" (protocol identifier)
-/// - Topic 2: "Deposit" (action)
-///
-/// Data payload contains user_address, amount, and timestamp.
 pub fn emit_deposit(e: &Env, user: Address, amount: i128) {
     e.events().publish(
         (PROTOCOL, ACT_DEPOSIT),
         DepositEvent {
-            user_address: user,
+            user,
             amount,
             timestamp: e.ledger().timestamp(),
         },
     );
 }
 
-/// Emits a standardized Withdraw event.
-///
-/// Topics:
-/// - Topic 1: "AxionVault" (protocol identifier)
-/// - Topic 2: "Withdraw" (action)
-///
-/// Data payload contains user_address, amount, and timestamp.
-pub fn emit_withdraw(e: &Env, user: Address, amount: i128) {
+pub fn emit_withdraw(e: &Env, user: Address, amount: i128, remaining_balance: i128) {
     e.events().publish(
         (PROTOCOL, ACT_WITHDRAW),
         WithdrawEvent {
-            user_address: user,
+            user,
             amount,
+            remaining_balance,
             timestamp: e.ledger().timestamp(),
         },
     );
 }
 
-/// Emits a standardized Distribute event.
-///
-/// Topics:
-/// - Topic 1: "AxionVault" (protocol identifier)
-/// - Topic 2: "Distribute" (action)
-///
-/// Data payload contains caller, amount, and timestamp.
 pub fn emit_distribute(e: &Env, caller: Address, amount: i128) {
     e.events().publish(
         (PROTOCOL, ACT_DISTRIBUTE),
@@ -221,18 +122,11 @@ pub fn emit_distribute(e: &Env, caller: Address, amount: i128) {
     );
 }
 
-/// Emits a standardized Claim event.
-///
-/// Topics:
-/// - Topic 1: "AxionVault" (protocol identifier)
-/// - Topic 2: "Claim" (action)
-///
-/// Data payload contains user_address, amount, and timestamp.
-pub fn emit_claim(e: &Env, user: Address, amount: i128) {
+pub fn emit_claim_rewards(e: &Env, user: Address, amount: i128) {
     e.events().publish(
         (PROTOCOL, ACT_CLAIM),
         ClaimEvent {
-            user_address: user,
+            user,
             amount,
             timestamp: e.ledger().timestamp(),
         },
@@ -256,6 +150,17 @@ pub fn emit_admin_transfer_accepted(e: &Env, previous_admin: Address, new_admin:
         AdminTransferAcceptedEvent {
             previous_admin,
             new_admin,
+            timestamp: e.ledger().timestamp(),
+        },
+    );
+}
+
+pub fn emit_upgrade(e: &Env, admin: Address, new_wasm_hash: BytesN<32>) {
+    e.events().publish(
+        (EVT_UPGRADE,),
+        UpgradeEvent {
+            admin,
+            new_wasm_hash,
             timestamp: e.ledger().timestamp(),
         },
     );

--- a/contracts/vault-contract/src/lib.rs
+++ b/contracts/vault-contract/src/lib.rs
@@ -7,7 +7,6 @@ mod storage;
 #[cfg(test)]
 mod test;
 
-use soroban_sdk::{contract, contractimpl, Address, Env};
 use soroban_sdk::{contract, contractimpl, Address, BytesN, Env};
 
 use crate::errors::{AuthorizationError, BalanceError, StateError, ValidationError, VaultError};
@@ -21,50 +20,23 @@ impl VaultContract {
         1
     }
 
-    /// Initializes the vault with the specified admin and token addresses.
-    ///
-    /// # Security Considerations
-    /// This function can only be called once. It checks the initialization state
-    /// using a dedicated storage flag. The provided `admin` address must authorize
-    /// the call to ensure that the person initializing the contract is indeed
-    /// the intended administrator.
-    ///
-    /// # Arguments
-    /// * `e` - The environment.
-    /// * `admin` - The address that will have administrative privileges (e.g., distributing rewards).
-    /// * `deposit_token` - The address of the token that users will deposit.
-    /// * `reward_token` - The address of the token that will be distributed as rewards.
-    ///
-    /// # Errors
-    /// * `VaultError::AlreadyInitialized` - If the vault has already been initialized.
-    /// * `VaultError::InvalidTokenConfiguration` - If the deposit and reward tokens are the same.
     pub fn initialize(
         e: Env,
         admin: Address,
         deposit_token: Address,
         reward_token: Address,
+        vesting_period: u64,
     ) -> Result<(), VaultError> {
         storage::require_not_paused(&e)?;
         if storage::is_initialized(&e) {
             return Err(StateError::AlreadyInitialized.into());
         }
 
-        // --- STEP 2: VALIDATION ---
-        // Basic sanity checks for the provided addresses.
         validate_distinct_token_addresses(&deposit_token, &reward_token)?;
         
-        // --- STEP 3: AUTHENTICATION ---
-        // We require the admin to sign this transaction. This prevents front-running
-        // by an attacker who might try to initialize the contract with their own address
-        // if the deployer doesn't include the initialization in the deployment transaction.
         admin.require_auth();
 
-        // --- STEP 4: STATE INITIALIZATION ---
-        // Persist the initial state to the contract's instance storage.
-        storage::initialize_state(&e, &admin, &deposit_token, &reward_token);
-        
-        // --- STEP 5: EVENT EMISSION ---
-        // Emit an event for indexers and off-chain monitoring.
+        storage::initialize_state(&e, &admin, &deposit_token, &reward_token, vesting_period);
         events::emit_initialize(&e, admin, deposit_token, reward_token);
 
         Ok(())
@@ -107,21 +79,6 @@ impl VaultContract {
         Ok(())
     }
 
-    /// Deposits tokens into the vault and accrues pending rewards before updating balance.
-    ///
-    /// This function handles the transfer of tokens from the user to the contract.
-    /// It ensures that rewards are accrued for the user's previous balance before
-    /// the new deposit increases their stake.
-    ///
-    /// # Arguments
-    /// * `e` - The environment.
-    /// * `from` - The address of the user depositing tokens.
-    /// * `amount` - The amount of tokens to deposit.
-    ///
-    /// # Errors
-    /// * `VaultError::NotInitialized` - If the vault hasn't been initialized.
-    /// * `VaultError::InvalidAmount` - If the amount is zero or negative.
-    /// * `VaultError::ReentrancyDetected` - If called recursively.
     pub fn deposit(e: Env, from: Address, amount: i128) -> Result<(), VaultError> {
         storage::require_not_paused(&e)?;
         storage::require_initialized(&e)?;
@@ -137,16 +94,6 @@ impl VaultContract {
         })
     }
 
-    /// Withdraws tokens from the vault and accrues pending rewards before updating balance.
-    ///
-    /// This function is isolated from reward claiming - it only handles the deposit token.
-    /// This "separation of concerns" ensures that even if the reward token contract is
-    /// malfunctioning, users can still recover their initial deposits.
-    ///
-    /// # Arguments
-    /// * `e` - The environment.
-    /// * `to` - The address of the user withdrawing tokens.
-    /// * `amount` - The amount of tokens to withdraw.
     pub fn withdraw(e: Env, to: Address, amount: i128) -> Result<(), VaultError> {
         storage::require_initialized(&e)?;
         validate_positive_amount(amount)?;
@@ -158,65 +105,36 @@ impl VaultContract {
             events::emit_withdraw(&e, to.clone(), amount, position.balance);
 
             let token = soroban_sdk::token::Client::new(&e, &state.deposit_token);
-            // Adhering to Check-Effects-Interactions pattern.
             token.transfer(&e.current_contract_address(), &to, &amount);
 
-            events::emit_withdraw(&e, to, amount);
             Ok(())
         })
     }
 
-    /// Distributes rewards to all depositors by updating the global reward index.
-    ///
-    /// This is an administrative function that increases the cumulative rewards
-    /// per unit of deposit. It does not immediately transfer tokens to users;
-    /// instead, users accrue rewards lazily whenever they interact with the vault.
-    ///
-    /// # Arguments
-    /// * `e` - The environment.
-    /// * `amount` - The total amount of reward tokens to distribute.
     pub fn distribute_rewards(e: Env, amount: i128) -> Result<i128, VaultError> {
         storage::require_initialized(&e)?;
         validate_positive_amount(amount)?;
-/// Distributes rewards to all depositors by updating the global reward index.
-/// Does not immediately transfer rewards to users - they accrue lazily.
-/// 
-/// Security: Only admin can call this function.
-/// Minimum amount: 100,000 stroops to prevent dust spam attacks.
-pub fn distribute_rewards(e: Env, amount: i128) -> Result<i128, VaultError> {
-    storage::require_initialized(&e)?;
-    validate_positive_amount(amount)?;
 
-    // Prevent dust spam attacks by enforcing minimum amount
-    const MIN_REWARD_DISTRIBUTION: i128 = 100_000;
-    if amount < MIN_REWARD_DISTRIBUTION {
-        return Err(ValidationError::InsufficientRewardAmount.into());
-    }
+        const MIN_REWARD_DISTRIBUTION: i128 = 100_000;
+        if amount < MIN_REWARD_DISTRIBUTION {
+            return Err(ValidationError::InsufficientRewardAmount.into());
+        }
 
-    let state = storage::get_state(&e)?;
-    let admin = state.admin.clone();
-    let reward_token_id = state.reward_token.clone();
+        let state = storage::get_state(&e)?;
+        let admin = state.admin.clone();
+        let reward_token_id = state.reward_token.clone();
 
-    admin.require_auth();
+        admin.require_auth();
 
         with_non_reentrant(&e, || {
             let next_state = storage::store_reward_distribution(&e, amount)?;
             let reward_token = soroban_sdk::token::Client::new(&e, &reward_token_id);
             reward_token.transfer(&admin, &e.current_contract_address(), &amount);
-            events::emit_distribute_rewards(&e, amount, next_index);
             events::emit_distribute(&e, admin.clone(), amount);
-            Ok(next_index)
+            Ok(next_state.reward_index)
         })
     }
 
-    /// Claims all accrued rewards for the calling user.
-    ///
-    /// This function calculates all pending rewards since the user's last interaction
-    /// and transfers them from the contract's balance to the user.
-    ///
-    /// # Arguments
-    /// * `e` - The environment.
-    /// * `user` - The address of the user claiming rewards.
     pub fn claim_rewards(e: Env, user: Address) -> Result<i128, VaultError> {
         storage::require_initialized(&e)?;
         user.require_auth();
@@ -251,6 +169,14 @@ pub fn distribute_rewards(e: Env, amount: i128) -> Result<i128, VaultError> {
 
     pub fn pending_rewards(e: Env, user: Address) -> Result<i128, VaultError> {
         storage::pending_user_rewards_view(&e, &user)
+    }
+
+    pub fn vested_rewards(e: Env, user: Address) -> Result<i128, VaultError> {
+        storage::vested_user_rewards_view(&e, &user)
+    }
+
+    pub fn vesting_period(e: Env) -> Result<u64, VaultError> {
+        storage::get_vesting_period(&e)
     }
 
     pub fn admin(e: Env) -> Result<Address, VaultError> {
@@ -288,10 +214,9 @@ pub fn distribute_rewards(e: Env, amount: i128) -> Result<i128, VaultError> {
         }
         admin.require_auth();
         storage::set_paused(&e, false);
-    /// Upgrades the contract WASM to a new version.
-    /// Only the admin can perform this action.
-    /// The new WASM hash must reference a valid, already-uploaded WASM that
-    /// is compatible with the current storage layout.
+        Ok(())
+    }
+
     pub fn upgrade(e: Env, admin: Address, new_wasm_hash: BytesN<32>) -> Result<(), VaultError> {
         storage::require_initialized(&e)?;
         admin.require_auth();
@@ -325,7 +250,6 @@ fn validate_distinct_token_addresses(
     if deposit_token == reward_token {
         return Err(ValidationError::InvalidTokenConfiguration.into());
     }
-
     Ok(())
 }
 
@@ -346,10 +270,6 @@ where
     result
 }
 
-// ---------------------------------------------------------------------------
-// Precision math unit tests  (issue #81)
-// ---------------------------------------------------------------------------
-
 #[cfg(test)]
 mod precision_tests {
     use super::storage::{checked_accrued_rewards, checked_reward_index_increment, PRECISION_FACTOR};
@@ -357,15 +277,12 @@ mod precision_tests {
 
     #[test]
     fn increment_basic() {
-        // 400 rewards / 400 total => index += 1 * PRECISION_FACTOR
         let inc = checked_reward_index_increment(400, 400).unwrap();
         assert_eq!(inc, PRECISION_FACTOR);
     }
 
     #[test]
     fn increment_small_reward_large_deposits_retains_precision() {
-        // 1 reward token, 1_000_000 deposited.
-        // Without scaling this would be 0; with PRECISION_FACTOR it is non-zero.
         let inc = checked_reward_index_increment(1, 1_000_000).unwrap();
         assert!(inc > 0, "precision lost: increment rounded to zero");
         assert_eq!(inc, PRECISION_FACTOR / 1_000_000);
@@ -389,8 +306,6 @@ mod precision_tests {
 
     #[test]
     fn accrued_proportional_equal_deposits() {
-        // Both users deposited 100 each (200 total), 400 rewards distributed.
-        // index increment = (400 * PRECISION_FACTOR) / 200 = 2 * PRECISION_FACTOR
         let delta = checked_reward_index_increment(400, 200).unwrap();
         let reward = checked_accrued_rewards(100, delta).unwrap();
         assert_eq!(reward, 200);
@@ -398,7 +313,6 @@ mod precision_tests {
 
     #[test]
     fn accrued_vastly_different_deposits_user_a_tiny() {
-        // User A: 1 token, User B: 1_000_000 tokens. 1_000_001 rewards distributed.
         let total = 1_000_001_i128;
         let rewards = 1_000_001_i128;
         let delta = checked_reward_index_increment(rewards, total).unwrap();
@@ -428,132 +342,11 @@ mod precision_tests {
 
     #[test]
     fn round_trip_proportionality() {
-        // Alice: 1 token, Bob: 999_999 tokens. 1_000_000 rewards.
         let total = 1_000_000_i128;
         let rewards = 1_000_000_i128;
         let delta = checked_reward_index_increment(rewards, total).unwrap();
 
         assert_eq!(checked_accrued_rewards(1, delta).unwrap(), 1);
         assert_eq!(checked_accrued_rewards(999_999, delta).unwrap(), 999_999);
-    }
-}
-
-// TODO(gas): Consider merging per-user keys (balance/index/rewards) into a single struct to reduce reads.
-// TODO(security): Consider adding pausability or per-user deposit caps.
-// TODO(upgradeability): Evaluate upgrade patterns compatible with Soroban best practices.
-
-#[cfg(test)]
-mod tests {
-    extern crate std;
-
-    use soroban_sdk::{
-        symbol_short,
-        testutils::{Address as _, Events, Register},
-        Address, Env, IntoVal, TryFromVal, Val, Vec,
-    };
-
-    use super::{
-        events::{AdminTransferAcceptedEvent, AdminTransferProposedEvent},
-        VaultContract, VaultContractClient,
-    };
-    use crate::errors::VaultError;
-
-    #[test]
-    fn admin_transfer_is_two_step() {
-        let env = Env::default();
-        env.mock_all_auths();
-
-        let contract_id = VaultContract.register(&env, None, ());
-        let client = VaultContractClient::new(&env, &contract_id);
-
-        let admin = Address::generate(&env);
-        let new_admin = Address::generate(&env);
-        let deposit_token = Address::generate(&env);
-        let reward_token = Address::generate(&env);
-
-        client.initialize(&admin, &deposit_token, &reward_token);
-        client.propose_new_admin(&admin, &new_admin);
-
-        assert_eq!(client.admin(), admin);
-        assert_eq!(client.pending_admin(), Some(new_admin.clone()));
-
-        client.accept_admin(&new_admin);
-
-        assert_eq!(client.admin(), new_admin);
-        assert_eq!(client.pending_admin(), None);
-    }
-
-    #[test]
-    fn accept_admin_requires_pending_admin_match() {
-        let env = Env::default();
-        env.mock_all_auths();
-
-        let contract_id = VaultContract.register(&env, None, ());
-        let client = VaultContractClient::new(&env, &contract_id);
-
-        let admin = Address::generate(&env);
-        let proposed_admin = Address::generate(&env);
-        let wrong_admin = Address::generate(&env);
-        let deposit_token = Address::generate(&env);
-        let reward_token = Address::generate(&env);
-
-        client.initialize(&admin, &deposit_token, &reward_token);
-        client.propose_new_admin(&admin, &proposed_admin);
-
-        let err = client.try_accept_admin(&wrong_admin).unwrap_err();
-        assert_eq!(err, Ok(VaultError::Unauthorized));
-        assert_eq!(client.admin(), admin);
-        assert_eq!(client.pending_admin(), Some(proposed_admin));
-    }
-
-    #[test]
-    fn proposing_and_accepting_emit_specific_events() {
-        let env = Env::default();
-        env.mock_all_auths();
-
-        let contract_id = VaultContract.register(&env, None, ());
-        let client = VaultContractClient::new(&env, &contract_id);
-
-        let admin = Address::generate(&env);
-        let new_admin = Address::generate(&env);
-        let deposit_token = Address::generate(&env);
-        let reward_token = Address::generate(&env);
-
-        client.initialize(&admin, &deposit_token, &reward_token);
-        client.propose_new_admin(&admin, &new_admin);
-        let proposed_events = env.events().all();
-        let proposed = proposed_events.last().unwrap();
-
-        assert_eq!(proposed.0, contract_id.clone());
-        assert_eq!(proposed.1, topics(&env, symbol_short!("adm_prop")));
-        assert_eq!(
-            AdminTransferProposedEvent::try_from_val(&env, &proposed.2).unwrap(),
-            AdminTransferProposedEvent {
-                current_admin: admin.clone(),
-                pending_admin: new_admin.clone(),
-                timestamp: env.ledger().timestamp(),
-            }
-        );
-
-        client.accept_admin(&new_admin);
-        let accepted_events = env.events().all();
-        let accepted = accepted_events.last().unwrap();
-
-        assert_eq!(accepted.0, contract_id);
-        assert_eq!(accepted.1, topics(&env, symbol_short!("adm_acpt")));
-        assert_eq!(
-            AdminTransferAcceptedEvent::try_from_val(&env, &accepted.2).unwrap(),
-            AdminTransferAcceptedEvent {
-                previous_admin: admin,
-                new_admin,
-                timestamp: env.ledger().timestamp(),
-            }
-        );
-    }
-
-    fn topics(env: &Env, topic: soroban_sdk::Symbol) -> Vec<Val> {
-        let mut values = Vec::new(env);
-        values.push_back(topic.into_val(env));
-        values
     }
 }

--- a/contracts/vault-contract/src/storage.rs
+++ b/contracts/vault-contract/src/storage.rs
@@ -3,6 +3,7 @@ use soroban_sdk::{contracttype, Address, Env};
 use crate::errors::{ArithmeticError, AuthorizationError, BalanceError, StateError, VaultError};
 
 pub const PRECISION_FACTOR: i128 = 1_000_000_000;
+const REWARD_INDEX_SCALE: i128 = PRECISION_FACTOR;
 
 const INSTANCE_TTL_THRESHOLD: u32 = 518_400;
 const INSTANCE_TTL_EXTEND_TO: u32 = 518_400;
@@ -11,42 +12,40 @@ const PERSISTENT_TTL_THRESHOLD: u32 = 518_400;
 const PERSISTENT_TTL_EXTEND_TO: u32 = 518_400;
 
 /// Keys used to store data in the contract's storage.
-/// Soroban supports three types of storage:
-/// 1. Temporary: Cheap, but can be deleted if not extended.
-/// 2. Instance: Tied to the contract instance, shared by all users.
-/// 3. Persistent: Long-term storage for user-specific data.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DataKey {
     /// Flag indicating if the contract has been initialized.
-    /// Stores a boolean value.
-    Initialized(bool),
-    /// The global state of the vault.
-    /// Stores a `VaultState` struct.
-    State,
-    /// User-specific position data (balance, rewards, etc.).
-    /// Stores a `UserPosition` struct for a specific `Address`.
-    UserPosition(Address),
-    /// A guard to prevent reentrant calls to sensitive functions.
-    /// Stores a boolean value.
-    ReentrancyGuard,
-    ReentrancyGuard,
+    Initialized,
+    /// Admin address
     Admin,
+    /// Pending admin address (for two-step transfer)
     PendingAdmin,
+    /// Deposit token address
     DepositToken,
+    /// Reward token address
     RewardToken,
+    /// Total deposits amount
     TotalDeposits,
+    /// Global reward index
     RewardIndex,
+    /// Vesting period in seconds
+    VestingPeriod,
+    /// Reentrancy guard flag
     ReentrancyGuard,
-    UserBalance(Address),
-    UserRewardIndex(Address),
-    UserRewards(Address),
-    ReentrancyGuard,
+    /// Pause flag
     IsPaused,
+    /// User balance
+    UserBalance(Address),
+    /// User's last synced reward index
+    UserRewardIndex(Address),
+    /// User's accrued but unvested rewards
+    UserAccruedRewards(Address),
+    /// User's last reward distribution timestamp (for vesting calculation)
+    UserLastRewardTimestamp(Address),
 }
 
 /// The global state of the vault contract.
-/// This struct is stored in instance storage and updated frequently.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct VaultState {
@@ -59,67 +58,36 @@ pub struct VaultState {
     /// The total amount of deposit tokens currently held by the vault.
     pub total_deposits: i128,
     /// The global reward index that tracks cumulative rewards per unit of deposit.
-    /// It increases whenever `distribute_rewards` is called.
     pub reward_index: i128,
+    /// The vesting period in seconds.
+    pub vesting_period: u64,
 }
 
 /// Snapshot of a user's position in the vault.
-/// This is stored in persistent storage for each user.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UserPosition {
     /// The amount of deposit tokens the user has currently staked.
     pub balance: i128,
     /// The value of the global reward index at the time of the user's last interaction.
-    /// Used to calculate newly accrued rewards since that interaction.
     pub reward_index: i128,
-    /// The amount of rewards the user has earned but not yet claimed.
-    pub rewards: i128,
+    /// The amount of rewards the user has earned but not yet vested/claimed.
+    pub accrued_rewards: i128,
+    /// The timestamp of the last reward distribution affecting this user.
+    pub last_reward_timestamp: u64,
 }
 
 /// A helper struct for returning reward information in view functions.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct VaultState {
-    pub admin: Address,
-    pub deposit_token: Address,
-    pub reward_token: Address,
-    pub total_deposits: i128,
-    pub reward_index: i128,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct UserPosition {
-    pub balance: i128,
-    pub reward_index: i128,
-    pub rewards: i128,
-}
-
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UserRewardSnapshot {
     /// The current reward index applied to the snapshot.
     pub reward_index: i128,
     /// The total rewards (accrued + pending) for the user.
     pub rewards: i128,
+    /// The amount of vested rewards available to claim.
+    pub vested_rewards: i128,
 }
 
-/// Checks if the contract has been initialized.
-///
-/// Returns `true` if initialized, `false` otherwise.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct VaultState {
-    pub admin: Address,
-    pub deposit_token: Address,
-    pub reward_token: Address,
-    pub total_deposits: i128,
-    pub reward_index: i128,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct UserPosition {
-    pub balance: i128,
-    pub reward_index: i128,
-    pub rewards: i128,
-}
 // ---------------------------------------------------------------------------
 // Init
 // ---------------------------------------------------------------------------
@@ -127,14 +95,10 @@ pub struct UserPosition {
 pub fn is_initialized(e: &Env) -> bool {
     e.storage()
         .instance()
-        .get::<_, bool>(&DataKey::Initialized(true))
+        .get::<_, bool>(&DataKey::Initialized)
         .unwrap_or(false)
 }
 
-/// Ensures the contract is initialized, returning an error if not.
-///
-/// # Errors
-/// * `VaultError::NotInitialized` - If the contract has not been initialized.
 pub fn require_initialized(e: &Env) -> Result<(), VaultError> {
     if is_initialized(e) {
         Ok(())
@@ -143,134 +107,89 @@ pub fn require_initialized(e: &Env) -> Result<(), VaultError> {
     }
 }
 
-/// Initializes the contract state and sets the initialization flag.
-///
-/// This should only be called by the `initialize` function in `lib.rs`.
-pub fn initialize_state(e: &Env, admin: &Address, deposit_token: &Address, reward_token: &Address) {
-    let state = VaultState {
-        admin: admin.clone(),
-        deposit_token: deposit_token.clone(),
-        reward_token: reward_token.clone(),
-        total_deposits: 0,
-        reward_index: 0,
-    };
-    e.storage().instance().set(&DataKey::State, &state);
-    e.storage().instance().set(&DataKey::Initialized(true), &true);
-    bump_instance_ttl(e);
-}
-
-/// Retrieves the global vault state.
-///
-/// # Errors
-/// * `VaultError::NotInitialized` - If the state is not found.
-pub fn get_state(e: &Env) -> Result<VaultState, VaultError> {
-    require_initialized(e)?;
-    let state: VaultState = e
-        bump_instance_ttl(e);
-        Ok(())
+pub fn require_not_paused(e: &Env) -> Result<(), VaultError> {
+    if e.storage().instance().get::<_, bool>(&DataKey::IsPaused).unwrap_or(false) {
+        Err(AuthorizationError::Unauthorized.into())
     } else {
-        Err(StateError::NotInitialized.into())
+        Ok(())
     }
 }
 
-fn bump_instance_ttl(e: &Env) {
-    e.storage()
-        .instance()
-        .extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
-}
-
-fn bump_persistent_ttl(e: &Env, key: &DataKey) {
-    e.storage()
-        .persistent()
-        .extend_ttl(key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
-pub fn initialize_state(e: &Env, admin: &Address, deposit_token: &Address, reward_token: &Address) {
+pub fn initialize_state(
+    e: &Env,
+    admin: &Address,
+    deposit_token: &Address,
+    reward_token: &Address,
+    vesting_period: u64,
+) {
     e.storage().instance().set(&DataKey::Initialized, &true);
     e.storage().instance().set(&DataKey::Admin, admin);
     e.storage().instance().remove(&DataKey::PendingAdmin);
-    e.storage()
-        .instance()
-        .set(&DataKey::DepositToken, deposit_token);
-    e.storage()
-        .instance()
-        .set(&DataKey::RewardToken, reward_token);
-    e.storage().instance().set(&DataKey::TotalDeposits, &0_i128);
-    e.storage().instance().set(&DataKey::RewardIndex, &0_i128);
-    e.storage()
-        .instance()
-        .set(&DataKey::ReentrancyGuard, &false);
-    bump_instance_ttl(e);
-}
-
-pub fn enter_non_reentrant(e: &Env) -> Result<(), VaultError> {
-    if e.storage()
-        .instance()
-        .get::<_, bool>(&DataKey::ReentrancyGuard)
-        .unwrap_or(false)
-    {
-        return Err(AuthorizationError::ReentrancyDetected.into());
-    }
-
-    e.storage().instance().set(&DataKey::ReentrancyGuard, &true);
-    bump_instance_ttl(e);
-    Ok(())
-}
-
-pub fn exit_non_reentrant(e: &Env) {
-    e.storage().instance().set(&DataKey::ReentrancyGuard, &false);
-    bump_instance_ttl(e);
-}
-
-pub fn initialize_state(e: &Env, admin: &Address, deposit_token: &Address, reward_token: &Address) {
-    e.storage().instance().set(&DataKey::Initialized, &true);
-    e.storage().instance().set(&DataKey::Admin, admin);
     e.storage().instance().set(&DataKey::DepositToken, deposit_token);
     e.storage().instance().set(&DataKey::RewardToken, reward_token);
+    e.storage().instance().set(&DataKey::VestingPeriod, &vesting_period);
     e.storage().instance().set(&DataKey::TotalDeposits, &0_i128);
     e.storage().instance().set(&DataKey::RewardIndex, &0_i128);
     e.storage().instance().set(&DataKey::ReentrancyGuard, &false);
-    bump_instance_ttl(e);
-    e.storage()
-        .instance()
-        .set(&DataKey::ReentrancyGuard, &false);
+    e.storage().instance().set(&DataKey::IsPaused, &false);
     bump_instance_ttl(e);
 }
 
-pub fn get_state(e: &Env) -> Result<VaultState, VaultError> {
-    Ok(VaultState {
-        admin: get_admin(e)?,
-        deposit_token: get_deposit_token(e)?,
-        reward_token: get_reward_token(e)?,
-        total_deposits: get_total_deposits(e)?,
-        reward_index: get_reward_index(e)?,
-    })
-}
+// ---------------------------------------------------------------------------
+// State (global)
+// ---------------------------------------------------------------------------
 
 pub fn get_state(e: &Env) -> Result<VaultState, VaultError> {
     require_initialized(e)?;
-    let state = VaultState {
-        admin: e.storage().instance().get(&DataKey::Admin).ok_or(StateError::NotInitialized)?,
-        deposit_token: e.storage().instance().get(&DataKey::DepositToken).ok_or(StateError::NotInitialized)?,
-        reward_token: e.storage().instance().get(&DataKey::RewardToken).ok_or(StateError::NotInitialized)?,
-        total_deposits: e.storage().instance().get(&DataKey::TotalDeposits).unwrap_or(0_i128),
-        reward_index: e.storage().instance().get(&DataKey::RewardIndex).unwrap_or(0_i128),
-    };
     let admin = e
         .storage()
         .instance()
         .get(&DataKey::Admin)
         .ok_or(StateError::InvalidState)?;
+    let deposit_token = e
+        .storage()
+        .instance()
+        .get(&DataKey::DepositToken)
+        .ok_or(StateError::InvalidState)?;
+    let reward_token = e
+        .storage()
+        .instance()
+        .get(&DataKey::RewardToken)
+        .ok_or(StateError::InvalidState)?;
+    let total_deposits = e
+        .storage()
+        .instance()
+        .get(&DataKey::TotalDeposits)
+        .unwrap_or(0_i128);
+    let reward_index = e
+        .storage()
+        .instance()
+        .get(&DataKey::RewardIndex)
+        .unwrap_or(0_i128);
+    let vesting_period = e
+        .storage()
+        .instance()
+        .get(&DataKey::VestingPeriod)
+        .unwrap_or(0_u64);
     bump_instance_ttl(e);
-    Ok(admin)
+    Ok(VaultState {
+        admin,
+        deposit_token,
+        reward_token,
+        total_deposits,
+        reward_index,
+        vesting_period,
+    })
 }
 
-/// Updates the global vault state.
-pub fn set_state(e: &Env, state: &VaultState) {
-    e.storage().instance().set(&DataKey::State, state);
-    e.storage().instance().set(&DataKey::TotalDeposits, &state.total_deposits);
-    e.storage().instance().set(&DataKey::RewardIndex, &state.reward_index);
-// ---------------------------------------------------------------------------
-// State (global)
-// ---------------------------------------------------------------------------
+pub fn get_admin(e: &Env) -> Result<Address, VaultError> {
+    Ok(get_state(e)?.admin)
+}
+
+pub fn set_admin(e: &Env, admin: &Address) {
+    e.storage().instance().set(&DataKey::Admin, admin);
+    bump_instance_ttl(e);
+}
 
 pub fn get_pending_admin(e: &Env) -> Result<Option<Address>, VaultError> {
     require_initialized(e)?;
@@ -279,19 +198,11 @@ pub fn get_pending_admin(e: &Env) -> Result<Option<Address>, VaultError> {
     Ok(pending)
 }
 
-/// Retrieves the admin address from the vault state.
-pub fn get_admin(e: &Env) -> Result<Address, VaultError> {
-    Ok(get_state(e)?.admin)
 pub fn set_pending_admin(e: &Env, pending_admin: &Address) {
-    e.storage()
-        .instance()
-        .set(&DataKey::PendingAdmin, pending_admin);
+    e.storage().instance().set(&DataKey::PendingAdmin, pending_admin);
     bump_instance_ttl(e);
 }
 
-/// Retrieves the deposit token address from the vault state.
-pub fn get_deposit_token(e: &Env) -> Result<Address, VaultError> {
-    Ok(get_state(e)?.deposit_token)
 pub fn clear_pending_admin(e: &Env) {
     e.storage().instance().remove(&DataKey::PendingAdmin);
     bump_instance_ttl(e);
@@ -299,194 +210,43 @@ pub fn clear_pending_admin(e: &Env) {
 
 pub fn get_deposit_token(e: &Env) -> Result<Address, VaultError> {
     Ok(get_state(e)?.deposit_token)
-    require_initialized(e)?;
-    let token = e
-        .storage()
-        .instance()
-        .get(&DataKey::DepositToken)
-        .ok_or(StateError::InvalidState)?;
-    bump_instance_ttl(e);
-    Ok(token)
 }
 
-/// Retrieves the reward token address from the vault state.
 pub fn get_reward_token(e: &Env) -> Result<Address, VaultError> {
-    require_initialized(e)?;
-    let token = e
-        .storage()
-        .instance()
-        .get(&DataKey::RewardToken)
-        .ok_or(StateError::InvalidState)?;
-    bump_instance_ttl(e);
-    Ok(token)
+    Ok(get_state(e)?.reward_token)
 }
 
-/// Retrieves the total amount of deposits from the vault state.
 pub fn get_total_deposits(e: &Env) -> Result<i128, VaultError> {
     Ok(get_state(e)?.total_deposits)
 }
 
-/// Retrieves the current reward index from the vault state.
-pub fn get_reward_index(e: &Env) -> Result<i128, VaultError> {
-    Ok(get_state(e)?.reward_index)
-}
-
-/// Retrieves a user's position data from persistent storage.
-///
-/// If no position exists, returns a default position with 0 balance
-/// and the current global reward index.
-pub fn get_user_position(e: &Env, user: &Address) -> Result<UserPosition, VaultError> {
-    require_initialized(e)?;
-    let key = DataKey::UserPosition(user.clone());
-    let position = e
-        .storage()
-        .persistent()
-        .get(&key)
-        .unwrap_or(UserPosition {
-            balance: 0,
-            reward_index: get_reward_index(e)?,
-            rewards: 0,
-        });
-    bump_persistent_ttl(e, &key);
-    Ok(position)
-}
-
-/// Retrieves a user's position, ignoring errors (useful for internal calculations).
-pub fn get_user_position_unchecked(e: &Env, user: &Address) -> UserPosition {
-    get_user_position(e, user).unwrap_or(UserPosition {
-        balance: 0,
-        reward_index: get_reward_index(e).unwrap_or(0),
-        rewards: 0,
-    })
-}
-
-/// Persists a user's position data to persistent storage.
-pub fn set_user_position(e: &Env, user: &Address, position: &UserPosition) {
-    let key = DataKey::UserPosition(user.clone());
-    e.storage().persistent().set(&key, position);
-    bump_persistent_ttl(e, &key);
-}
-
-/// Retrieves just the balance part of a user's position.
-pub fn get_user_balance(e: &Env, user: &Address) -> Result<i128, VaultError> {
-    Ok(get_user_position(e, user)?.balance)
-pub fn get_reward_index(e: &Env) -> Result<i128, VaultError> {
-    Ok(get_state(e)?.reward_index)
-}
-
-pub fn get_user_balance_and_extend(e: &Env, user: &Address) -> i128 {
-    let key = DataKey::UserBalance(user.clone());
-    if let Some(bal) = e.storage().persistent().get(&key) {
-        bump_persistent_ttl(e, &key);
-        bal
-    } else {
-        0_i128
-    }
-}
-
-pub fn set_user_balance_and_extend(e: &Env, user: &Address, balance: i128) {
-    let key = DataKey::UserBalance(user.clone());
-    if balance == 0 {
-        e.storage().persistent().remove(&key);
-    } else {
-        e.storage().persistent().set(&key, &balance);
-        bump_persistent_ttl(e, &key);
-    require_initialized(e)?;
-    let total = e
-        .storage()
-        .instance()
-        .get(&DataKey::TotalDeposits)
-        .ok_or(StateError::InvalidState)?;
+pub fn set_total_deposits(e: &Env, total: i128) {
+    e.storage().instance().set(&DataKey::TotalDeposits, &total);
     bump_instance_ttl(e);
-    Ok(total)
 }
 
 pub fn get_reward_index(e: &Env) -> Result<i128, VaultError> {
     Ok(get_state(e)?.reward_index)
 }
 
-pub fn get_reward_index(e: &Env) -> Result<i128, VaultError> {
-    require_initialized(e)?;
-    let reward_index = e
-        .storage()
-        .instance()
-        .get(&DataKey::RewardIndex)
-        .ok_or(StateError::InvalidState)?;
-    bump_instance_ttl(e);
-    Ok(reward_index)
-}
-
-pub fn set_reward_index(e: &Env, reward_index: i128) {
-    e.storage()
-        .instance()
-        .set(&DataKey::RewardIndex, &reward_index);
+pub fn set_reward_index(e: &Env, index: i128) {
+    e.storage().instance().set(&DataKey::RewardIndex, &index);
     bump_instance_ttl(e);
 }
 
-pub fn get_user_position(e: &Env, user: &Address) -> Result<UserPosition, VaultError> {
-    require_initialized(e)?;
-    Ok(get_user_position_unchecked(e, user))
+pub fn get_vesting_period(e: &Env) -> Result<u64, VaultError> {
+    Ok(get_state(e)?.vesting_period)
 }
 
-fn get_user_position_unchecked(e: &Env, user: &Address) -> UserPosition {
-    let balance_key = DataKey::UserBalance(user.clone());
-    let reward_index_key = DataKey::UserRewardIndex(user.clone());
-    let rewards_key = DataKey::UserRewards(user.clone());
-
-    let balance = e.storage().persistent().get(&balance_key).unwrap_or(0_i128);
-    let reward_index = e
-        .storage()
-        .persistent()
-        .get(&reward_index_key)
-        .unwrap_or(0_i128);
-    let rewards = e.storage().persistent().get(&rewards_key).unwrap_or(0_i128);
-
-    if balance != 0 {
-        bump_persistent_ttl(e, &balance_key);
-    }
-    if reward_index != 0 {
-        bump_persistent_ttl(e, &reward_index_key);
-    }
-    if rewards != 0 {
-        bump_persistent_ttl(e, &rewards_key);
-    }
-
-pub fn get_user_reward_index_and_extend(e: &Env, user: &Address) -> i128 {
-    let key = DataKey::UserRewardIndex(user.clone());
-    if let Some(idx) = e.storage().persistent().get(&key) {
-        bump_persistent_ttl(e, &key);
-        idx
-    } else {
-        0_i128
-    }
+pub fn set_paused(e: &Env, paused: bool) {
+    e.storage().instance().set(&DataKey::IsPaused, &paused);
+    bump_instance_ttl(e);
 }
 
-pub fn set_user_reward_index_and_extend(e: &Env, user: &Address, index: i128) {
-    let key = DataKey::UserRewardIndex(user.clone());
-    e.storage().persistent().set(&key, &index);
-    bump_persistent_ttl(e, &key);
-}
+// ---------------------------------------------------------------------------
+// Reentrancy Guard
+// ---------------------------------------------------------------------------
 
-pub fn get_user_rewards_and_extend(e: &Env, user: &Address) -> i128 {
-    let key = DataKey::UserRewards(user.clone());
-    if let Some(rewards) = e.storage().persistent().get(&key) {
-        bump_persistent_ttl(e, &key);
-        rewards
-    } else {
-        0_i128
-    }
-}
-
-pub fn set_user_rewards_and_extend(e: &Env, user: &Address, rewards: i128) {
-    let key = DataKey::UserRewards(user.clone());
-    e.storage().persistent().set(&key, &rewards);
-    bump_persistent_ttl(e, &key);
-}
-
-/// Sets the reentrancy guard flag to prevent recursive calls.
-///
-/// # Errors
-/// * `VaultError::ReentrancyDetected` - If the guard is already set.
 pub fn enter_non_reentrant(e: &Env) -> Result<(), VaultError> {
     if e.storage()
         .instance()
@@ -500,46 +260,74 @@ pub fn enter_non_reentrant(e: &Env) -> Result<(), VaultError> {
     Ok(())
 }
 
-/// Clears the reentrancy guard flag.
 pub fn exit_non_reentrant(e: &Env) {
     e.storage().instance().set(&DataKey::ReentrancyGuard, &false);
-pub fn get_user_position_unchecked(e: &Env, user: &Address) -> UserPosition {
-    UserPosition {
-        balance: get_user_balance_and_extend(e, user),
-        reward_index: get_user_reward_index_and_extend(e, user),
-        rewards: get_user_rewards_and_extend(e, user),
-    }
+    bump_instance_ttl(e);
 }
+
+// ---------------------------------------------------------------------------
+// User Position
+// ---------------------------------------------------------------------------
 
 pub fn get_user_position(e: &Env, user: &Address) -> Result<UserPosition, VaultError> {
     require_initialized(e)?;
     Ok(get_user_position_unchecked(e, user))
 }
 
-pub fn set_user_position(e: &Env, user: &Address, position: &UserPosition) {
-    set_user_balance_and_extend(e, user, position.balance);
-    set_user_reward_index_and_extend(e, user, position.reward_index);
-    set_user_rewards_and_extend(e, user, position.rewards);
-}
+pub fn get_user_position_unchecked(e: &Env, user: &Address) -> UserPosition {
+    let balance_key = DataKey::UserBalance(user.clone());
+    let reward_index_key = DataKey::UserRewardIndex(user.clone());
+    let accrued_rewards_key = DataKey::UserAccruedRewards(user.clone());
+    let last_reward_timestamp_key = DataKey::UserLastRewardTimestamp(user.clone());
+
+    let balance = e.storage().persistent().get(&balance_key).unwrap_or(0_i128);
+    let reward_index = e
+        .storage()
+        .persistent()
+        .get(&reward_index_key)
+        .unwrap_or(0_i128);
+    let accrued_rewards = e
+        .storage()
+        .persistent()
+        .get(&accrued_rewards_key)
+        .unwrap_or(0_i128);
+    let last_reward_timestamp = e
+        .storage()
+        .persistent()
+        .get(&last_reward_timestamp_key)
+        .unwrap_or(0_u64);
+
+    if balance != 0 {
+        bump_persistent_ttl(e, &balance_key);
+    }
+    if reward_index != 0 {
+        bump_persistent_ttl(e, &reward_index_key);
+    }
+    if accrued_rewards != 0 {
+        bump_persistent_ttl(e, &accrued_rewards_key);
+    }
+    if last_reward_timestamp != 0 {
+        bump_persistent_ttl(e, &last_reward_timestamp_key);
+    }
 
     UserPosition {
         balance,
         reward_index,
-        rewards,
+        accrued_rewards,
+        last_reward_timestamp,
     }
 }
 
-fn set_user_position(e: &Env, user: &Address, position: &UserPosition) {
+pub fn set_user_position(e: &Env, user: &Address, position: &UserPosition) {
     let balance_key = DataKey::UserBalance(user.clone());
     let reward_index_key = DataKey::UserRewardIndex(user.clone());
-    let rewards_key = DataKey::UserRewards(user.clone());
+    let accrued_rewards_key = DataKey::UserAccruedRewards(user.clone());
+    let last_reward_timestamp_key = DataKey::UserLastRewardTimestamp(user.clone());
 
     if position.balance == 0 {
         e.storage().persistent().remove(&balance_key);
     } else {
-        e.storage()
-            .persistent()
-            .set(&balance_key, &position.balance);
+        e.storage().persistent().set(&balance_key, &position.balance);
         bump_persistent_ttl(e, &balance_key);
     }
 
@@ -552,24 +340,29 @@ fn set_user_position(e: &Env, user: &Address, position: &UserPosition) {
         bump_persistent_ttl(e, &reward_index_key);
     }
 
-    if position.rewards == 0 {
-        e.storage().persistent().remove(&rewards_key);
+    if position.accrued_rewards == 0 {
+        e.storage().persistent().remove(&accrued_rewards_key);
     } else {
         e.storage()
             .persistent()
-            .set(&rewards_key, &position.rewards);
-        bump_persistent_ttl(e, &rewards_key);
+            .set(&accrued_rewards_key, &position.accrued_rewards);
+        bump_persistent_ttl(e, &accrued_rewards_key);
     }
+
+    e.storage()
+        .persistent()
+        .set(&last_reward_timestamp_key, &position.last_reward_timestamp);
+    bump_persistent_ttl(e, &last_reward_timestamp_key);
 }
 
 pub fn get_user_balance(e: &Env, user: &Address) -> Result<i128, VaultError> {
     Ok(get_user_position(e, user)?.balance)
 }
 
-/// Logic for recording a deposit in the contract state.
-///
-/// This function updates the user's balance and the global total deposits.
-/// It also triggers reward accrual for the user based on their previous balance.
+// ---------------------------------------------------------------------------
+// Deposit/Withdraw Logic
+// ---------------------------------------------------------------------------
+
 pub fn store_deposit(
     e: &Env,
     user: &Address,
@@ -579,7 +372,7 @@ pub fn store_deposit(
     let mut position = get_user_position_unchecked(e, user);
     
     // Accrue rewards earned up to this point using the old balance.
-    accrue_position_rewards(&state, &mut position)?;
+    accrue_position_rewards(e, &state, &mut position)?;
 
     // Update balance and total deposits.
     position.balance = position
@@ -592,7 +385,6 @@ pub fn store_deposit(
         .ok_or(ArithmeticError::Overflow)?;
 
     // Persist changes.
-    set_state(e, &state);
     set_total_deposits(e, next_total);
     set_user_position(e, user, &position);
 
@@ -605,9 +397,6 @@ pub fn store_deposit(
     ))
 }
 
-/// Logic for recording a withdrawal in the contract state.
-///
-/// Ensures the user has enough balance and updates both user and global state.
 pub fn store_withdraw(
     e: &Env,
     user: &Address,
@@ -617,7 +406,7 @@ pub fn store_withdraw(
     let mut position = get_user_position_unchecked(e, user);
     
     // Accrue rewards earned up to this point using the old balance.
-    accrue_position_rewards(&state, &mut position)?;
+    accrue_position_rewards(e, &state, &mut position)?;
 
     if position.balance < amount {
         return Err(BalanceError::InsufficientBalance.into());
@@ -627,35 +416,13 @@ pub fn store_withdraw(
     position.balance = position
         .balance
         .checked_sub(amount)
-        .ok_or(VaultError::MathOverflow)?;
-    state.total_deposits = state
-        .total_deposits
-        .checked_sub(amount)
-        .ok_or(VaultError::MathOverflow)?;
-
-    // Persist changes.
-    set_state(e, &state);
-    set_user_position(e, user, &position);
-    Ok((state, position))
-    if state.total_deposits < amount {
-        return Err(StateError::InvalidState.into());
-    }
-
-    position.balance = position.balance.checked_sub(amount).unwrap();
-    state.total_deposits = state.total_deposits.checked_sub(amount).unwrap();
-
-    set_state(e, &state);
-    set_user_position(e, user, &position);
-    Ok((state, position))
-    position.balance = position
-        .balance
-        .checked_sub(amount)
         .ok_or(ArithmeticError::Overflow)?;
     let next_total = state
         .total_deposits
         .checked_sub(amount)
         .ok_or(ArithmeticError::Overflow)?;
 
+    // Persist changes.
     set_total_deposits(e, next_total);
     set_user_position(e, user, &position);
 
@@ -668,15 +435,14 @@ pub fn store_withdraw(
     ))
 }
 
-/// Logic for distributing rewards and updating the global reward index.
-///
-/// Calculates the index increment based on the distributed amount and total deposits.
+// ---------------------------------------------------------------------------
+// Reward Distribution
+// ---------------------------------------------------------------------------
+
 pub fn store_reward_distribution(e: &Env, amount: i128) -> Result<VaultState, VaultError> {
     let state = get_state(e)?;
     let increment = checked_reward_index_increment(amount, state.total_deposits)?;
 
-    // Increment the global index. All subsequent interactions will use this new index.
-    state.reward_index = state
     let next_reward_index = state
         .reward_index
         .checked_add(increment)
@@ -690,32 +456,63 @@ pub fn store_reward_distribution(e: &Env, amount: i128) -> Result<VaultState, Va
     })
 }
 
-/// Logic for claiming accrued rewards for a user.
-///
-/// Accrues all pending rewards and resets the user's rewards counter to zero.
+// ---------------------------------------------------------------------------
+// Claim Rewards
+// ---------------------------------------------------------------------------
+
+pub fn calculate_vested_rewards(
+    current_timestamp: u64,
+    position: &UserPosition,
+    vesting_period: u64,
+) -> Result<i128, VaultError> {
+    if vesting_period == 0 {
+        // No vesting period, all rewards are immediately vested
+        return Ok(position.accrued_rewards);
+    }
+
+    if position.last_reward_timestamp == 0 {
+        return Ok(0);
+    }
+
+    let time_elapsed = current_timestamp
+        .checked_sub(position.last_reward_timestamp)
+        .unwrap_or(0);
+
+    if time_elapsed >= vesting_period {
+        // All rewards are vested
+        Ok(position.accrued_rewards)
+    } else {
+        // Calculate partial vesting
+        let vested = (position.accrued_rewards as u128)
+            .checked_mul(time_elapsed as u128)
+            .ok_or(ArithmeticError::Overflow)?
+            .checked_div(vesting_period as u128)
+            .ok_or(ArithmeticError::RewardCalculationFailed)? as i128;
+        Ok(vested)
+    }
+}
+
 pub fn store_claimable_rewards(e: &Env, user: &Address) -> Result<i128, VaultError> {
     let state = get_state(e)?;
     let mut position = get_user_position_unchecked(e, user);
     
     // Accrue all rewards earned up to the current global index.
-    accrue_position_rewards(&state, &mut position)?;
+    accrue_position_rewards(e, &state, &mut position)?;
 
-    let claimable = position.rewards;
-    position.rewards = 0;
-    
-    // Reset the counter but keep the balance and current reward index.
+    // Calculate vested rewards
+    let current_timestamp = e.ledger().timestamp();
+    let vested = calculate_vested_rewards(current_timestamp, &position, state.vesting_period)?;
+
+    // Update position with remaining accrued rewards
+    position.accrued_rewards = position
+        .accrued_rewards
+        .checked_sub(vested)
+        .ok_or(ArithmeticError::Overflow)?;
+
     set_user_position(e, user, &position);
 
-    Ok(claimable)
+    Ok(vested)
 }
-
-/// Provides a read-only view of a user's pending rewards without modifying state.
-pub fn preview_user_rewards(e: &Env, user: &Address) -> Result<UserRewardSnapshot, VaultError> {
-    require_initialized(e)?;
-
-    if !is_initialized(e) {
-        return Err(StateError::NotInitialized.into());
-    }
 
 // ---------------------------------------------------------------------------
 // Read-only reward preview
@@ -724,44 +521,33 @@ pub fn preview_user_rewards(e: &Env, user: &Address) -> Result<UserRewardSnapsho
 pub fn preview_user_rewards(e: &Env, user: &Address) -> Result<UserRewardSnapshot, VaultError> {
     require_initialized(e)?;
     let state = get_state(e)?;
-    let position = get_user_position_unchecked(e, user);
-
-    // If global index hasn't moved or user has no balance, no new rewards.
-    if state.reward_index == position.reward_index || position.balance == 0 {
-        return Ok(UserRewardSnapshot {
-            reward_index: state.reward_index,
-            rewards: position.rewards,
-        });
-    }
-
-    // Calculate the hypothetical accrual.
-    let delta = state
-        .reward_index
-        .checked_sub(position.reward_index)
-        .ok_or(VaultError::MathOverflow)?;
-    let accrued = checked_accrued_rewards(position.balance, delta)?;
-    let rewards = position
-        .rewards
-        .checked_add(accrued)
-        .ok_or(VaultError::MathOverflow)?;
-    let state = get_state(e)?;
     let mut position = get_user_position_unchecked(e, user);
-    accrue_position_rewards(&state, &mut position)?;
+    
+    // Calculate accrued rewards without modifying state
+    accrue_position_rewards(e, &state, &mut position)?;
+
+    let current_timestamp = e.ledger().timestamp();
+    let vested = calculate_vested_rewards(current_timestamp, &position, state.vesting_period)?;
 
     Ok(UserRewardSnapshot {
         reward_index: position.reward_index,
-        rewards: position.rewards,
+        rewards: position.accrued_rewards,
+        vested_rewards: vested,
     })
 }
 
-/// View function for pending rewards.
 pub fn pending_user_rewards_view(e: &Env, user: &Address) -> Result<i128, VaultError> {
     Ok(preview_user_rewards(e, user)?.rewards)
 }
 
-/// Internal helper to calculate how much the reward index should increase.
-///
-/// Formula: `(amount * SCALE) / total_deposits`
+pub fn vested_user_rewards_view(e: &Env, user: &Address) -> Result<i128, VaultError> {
+    Ok(preview_user_rewards(e, user)?.vested_rewards)
+}
+
+// ---------------------------------------------------------------------------
+// Helper Functions
+// ---------------------------------------------------------------------------
+
 pub(crate) fn checked_reward_index_increment(
     amount: i128,
     total_deposits: i128,
@@ -784,21 +570,16 @@ pub(crate) fn checked_reward_index_increment(
     Ok(increment)
 }
 
-/// Internal helper to accrue rewards for a specific user position.
-///
-/// Updates `position.rewards` and syncs `position.reward_index` with `state.reward_index`.
 pub(crate) fn checked_accrued_rewards(balance: i128, delta: i128) -> Result<i128, VaultError> {
-    let scaled = balance
+    balance
         .checked_mul(delta)
-        .ok_or(VaultError::MathOverflow)?;
-    Ok(scaled / REWARD_INDEX_SCALE)
-}
-
-pub fn pending_user_rewards_view(e: &Env, user: &Address) -> Result<i128, VaultError> {
-    Ok(preview_user_rewards(e, user)?.rewards)
+        .ok_or(ArithmeticError::Overflow)?
+        .checked_div(REWARD_INDEX_SCALE)
+        .ok_or(ArithmeticError::RewardCalculationFailed.into())
 }
 
 fn accrue_position_rewards(
+    e: &Env,
     state: &VaultState,
     position: &mut UserPosition,
 ) -> Result<(), VaultError> {
@@ -815,42 +596,25 @@ fn accrue_position_rewards(
         let accrued = checked_accrued_rewards(position.balance, delta)?;
 
         if accrued > 0 {
-            position.rewards = position
-                .rewards
+            position.accrued_rewards = position
+                .accrued_rewards
                 .checked_add(accrued)
                 .ok_or(ArithmeticError::Overflow)?;
+            // Update last reward timestamp whenever new rewards are accrued
+            position.last_reward_timestamp = e.ledger().timestamp();
         }
     }
 
-    // Mark that the user is now synced with the current global reward index.
     position.reward_index = state.reward_index;
     Ok(())
 }
 
-/// Internal helper to calculate rewards based on balance and index delta.
-///
-/// Formula: `(balance * index_delta) / SCALE`
-fn checked_accrued_rewards(balance: i128, index_delta: i128) -> Result<i128, VaultError> {
-    balance
-        .checked_mul(index_delta)
-        .and_then(|v| v.checked_div(REWARD_INDEX_SCALE))
-        .ok_or(VaultError::MathOverflow)
-fn checked_accrued_rewards(balance: i128, reward_delta: i128) -> Result<i128, VaultError> {
-    balance
-        .checked_mul(reward_delta)
-        .ok_or(ArithmeticError::Overflow)?
-        .checked_div(REWARD_INDEX_SCALE)
-        .ok_or(ArithmeticError::RewardCalculationFailed.into())
-}
-
-/// Bumps the TTL for instance storage to keep the contract active.
 fn bump_instance_ttl(e: &Env) {
     e.storage()
         .instance()
         .extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
 }
 
-/// Bumps the TTL for a specific persistent storage key.
 fn bump_persistent_ttl(e: &Env, key: &DataKey) {
     e.storage()
         .persistent()

--- a/contracts/vault-contract/src/test.rs
+++ b/contracts/vault-contract/src/test.rs
@@ -9,28 +9,22 @@ use super::*;
 use soroban_sdk::{testutils::Address as _, Address, Env};
 
 /// Verifies that the contract can only be initialized once.
-//!
-//! This test attempts to call `initialize` twice and expects the second call
-//! to fail with the `AlreadyInitialized` error code.
 #[test]
 fn test_initialization_is_one_time() {
     let e = Env::default();
     e.mock_all_auths();
 
-    // Register the contract in the test environment.
     let contract_id = e.register_contract(None, VaultContract);
     let client = VaultContractClient::new(&e, &contract_id);
 
-    // Generate random addresses for the test.
     let admin = Address::generate(&e);
     let deposit_token = Address::generate(&e);
     let reward_token = Address::generate(&e);
+    let vesting_period = 86400u64; // 1 day
 
-    // First initialization should succeed.
-    client.initialize(&admin, &deposit_token, &reward_token);
+    client.initialize(&admin, &deposit_token, &reward_token, &vesting_period);
 
-    // Second initialization MUST fail with the specific error code.
-    let result = client.try_initialize(&admin, &deposit_token, &reward_token);
+    let result = client.try_initialize(&admin, &deposit_token, &reward_token, &vesting_period);
     
     assert_eq!(
         result,
@@ -39,13 +33,9 @@ fn test_initialization_is_one_time() {
 }
 
 /// Verifies that the `initialize` function requires the admin's authorization.
-//!
-//! This test ensures that an attacker cannot initialize the contract with someone
-//! else's address as the admin without their signature.
 #[test]
 fn test_initialize_requires_admin_auth() {
     let e = Env::default();
-    // Do NOT mock auths to verify that require_auth() actually triggers.
 
     let contract_id = e.register_contract(None, VaultContract);
     let client = VaultContractClient::new(&e, &contract_id);
@@ -53,12 +43,10 @@ fn test_initialize_requires_admin_auth() {
     let admin = Address::generate(&e);
     let deposit_token = Address::generate(&e);
     let reward_token = Address::generate(&e);
+    let vesting_period = 86400u64;
 
-    // This call should panic because admin hasn't authorized it in the mock environment.
-    // In a real environment, this would require a signature.
-    let result = client.try_initialize(&admin, &deposit_token, &reward_token);
+    let result = client.try_initialize(&admin, &deposit_token, &reward_token, &vesting_period);
     
-    // Check if it's an authentication error
     assert!(result.is_err());
 }
 
@@ -73,11 +61,82 @@ fn test_initialize_fails_with_same_tokens() {
 
     let admin = Address::generate(&e);
     let token = Address::generate(&e);
+    let vesting_period = 86400u64;
 
-    let result = client.try_initialize(&admin, &token, &token);
+    let result = client.try_initialize(&admin, &token, &token, &vesting_period);
     
     assert_eq!(
         result,
         Err(Ok(VaultError::InvalidTokenConfiguration))
     );
+}
+
+/// Tests vesting period functionality.
+#[test]
+fn test_vesting() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let contract_id = e.register_contract(None, VaultContract);
+    let client = VaultContractClient::new(&e, &contract_id);
+
+    let admin = Address::generate(&e);
+    let deposit_token = Address::generate(&e);
+    let reward_token = Address::generate(&e);
+    let vesting_period = 86400u64; // 1 day in seconds
+
+    client.initialize(&admin, &deposit_token, &reward_token, &vesting_period);
+
+    let user = Address::generate(&e);
+
+    // Set up mock token clients
+    let deposit_token_client = soroban_sdk::token::Client::new(&e, &deposit_token);
+    let reward_token_client = soroban_sdk::token::Client::new(&e, &reward_token);
+
+    // Mock token balances
+    e.as_contract(&deposit_token, || {
+        e.storage().instance().set(&soroban_sdk::token::DataKey::Admin, &admin);
+        e.storage().instance().set(&soroban_sdk::token::DataKey::Balance(user.clone()), &1000i128);
+        e.storage().instance().set(&soroban_sdk::token::DataKey::Balance(contract_id.clone()), &0i128);
+    });
+    e.as_contract(&reward_token, || {
+        e.storage().instance().set(&soroban_sdk::token::DataKey::Admin, &admin);
+        e.storage().instance().set(&soroban_sdk::token::DataKey::Balance(admin.clone()), &10000i128);
+        e.storage().instance().set(&soroban_sdk::token::DataKey::Balance(contract_id.clone()), &0i128);
+    });
+
+    // User deposits tokens
+    client.deposit(&user, &100i128);
+
+    // Set timestamp for distribution
+    e.ledger().set_timestamp(1000);
+
+    // Admin distributes rewards
+    client.distribute_rewards(&admin, &200000i128);
+
+    // Check pending rewards
+    let pending = client.pending_rewards(&user);
+    assert_eq!(pending, 200000);
+
+    // Check vested rewards immediately (should be 0)
+    let vested = client.vested_rewards(&user);
+    assert_eq!(vested, 0);
+
+    // Advance time halfway through vesting period
+    e.ledger().set_timestamp(1000 + 43200);
+
+    // Check vested rewards (should be half)
+    let vested = client.vested_rewards(&user);
+    assert_eq!(vested, 100000);
+
+    // Advance time past vesting period
+    e.ledger().set_timestamp(1000 + 86400 + 1);
+
+    // Check vested rewards (should be full)
+    let vested = client.vested_rewards(&user);
+    assert_eq!(vested, 200000);
+
+    // Claim rewards
+    let claimed = client.claim_rewards(&user);
+    assert_eq!(claimed, 200000);
 }


### PR DESCRIPTION
Closes #142 
Add configurable reward vesting period to the vault contract:
- Add VestingError type and map RewardsNotVested to VaultError code 17
- Add vesting_period parameter to initialize and store in contract state
- Update UserPosition struct to track accrued rewards and last reward timestamp
- Implement vested rewards calculation that vests over the configured period
- Modify claim logic to only transfer vested rewards
- Add `vested_rewards` and `vesting_period` public view functions
- Refactor storage and event definitions for better maintainability
- Add end-to-end vesting test suite
- Update all existing tests to include vesting period parameter