### PR TITLE
refactor: standardize protocol event definitions and naming

### DIFF
--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -291,7 +291,7 @@ Events are stored in the `events` table with the following columns:
 | `ledger_sequence` | INTEGER | Stellar ledger number |
 | `contract_id` | TEXT | Contract address |
 | `event_type` | TEXT | Event type |
-| `protocol` | TEXT | Protocol identifier (always "AxionVault") |
+| `protocol` | TEXT | Protocol identifier (always "AxVault") |
 | `action` | TEXT | Action type (e.g., "deposit", "withdraw") |
 | `user_address` | TEXT | User address (if applicable) |
 | `asset_address` | TEXT | Asset address (if applicable) |

--- a/docs/contract-spec.md
+++ b/docs/contract-spec.md
@@ -477,7 +477,7 @@ The contract emits standardized Soroban events for all state-changing actions. E
 
 All vault events use a **two-topic design** for efficient filtering:
 
-- **Topic 1 (Protocol Identifier)**: `Symbol("AxionVault")` — Identifies the protocol namespace
+- **Topic 1 (Protocol Identifier)**: `Symbol("AxVault")` — Identifies the protocol namespace
 - **Topic 2 (Action)**: Identifies the specific action (e.g., `Symbol("Deposit")`, `Symbol("Withdraw")`)
 - **Data Payload**: Structured tuple containing event-specific data (user_address, amount, timestamp)
 
@@ -492,7 +492,7 @@ This design allows indexers to rapidly filter by:
 
 **Topics:**
 
-- Topic 1: `Symbol("AxionVault")`
+- Topic 1: `Symbol("AxVault")`
 - Topic 2: `Symbol("Initialize")`
 
 **Data Payload (XDR Struct):**
@@ -512,7 +512,7 @@ struct InitializeEvent {
 
 **Topics:**
 
-- Topic 1: `Symbol("AxionVault")`
+- Topic 1: `Symbol("AxVault")`
 - Topic 2: `Symbol("Deposit")`
 
 **Data Payload (XDR Struct):**
@@ -531,7 +531,7 @@ struct DepositEvent {
 
 **Topics:**
 
-- Topic 1: `Symbol("AxionVault")`
+- Topic 1: `Symbol("AxVault")`
 - Topic 2: `Symbol("Withdraw")`
 
 **Data Payload (XDR Struct):**
@@ -550,7 +550,7 @@ struct WithdrawEvent {
 
 **Topics:**
 
-- Topic 1: `Symbol("AxionVault")`
+- Topic 1: `Symbol("AxVault")`
 - Topic 2: `Symbol("Distribute")`
 
 **Data Payload (XDR Struct):**
@@ -569,7 +569,7 @@ struct DistributeEvent {
 
 **Topics:**
 
-- Topic 1: `Symbol("AxionVault")`
+- Topic 1: `Symbol("AxVault")`
 - Topic 2: `Symbol("Claim")`
 
 **Data Payload (XDR Struct):**
@@ -588,7 +588,7 @@ struct ClaimEvent {
 
 Off-chain indexers should:
 
-1. **Subscribe to events with Topic 1 = `Symbol("AxionVault")`** to catch all vault events
+1. **Subscribe to events with Topic 1 = `Symbol("AxVault")`** to catch all vault events
 2. **Filter by Topic 2** to identify specific actions (Initialize, Deposit, Withdraw, Distribute, Claim)
 3. **Parse the data payload** to extract user_address, amount, and timestamp
 4. **Build the user dashboard** by aggregating Deposit, Withdraw, Distribute, and Claim events chronologically
@@ -600,7 +600,7 @@ Each event data payload is serialized as a Soroban ContractData XDR type. The in
 Example (pseudocode):
 
 ```
-event.topics[0] == Symbol("AxionVault")
+event.topics[0] == Symbol("AxVault")
 event.topics[1] == Symbol("Deposit")
 data = deserialize_xdr(event.data) as DepositEvent
 // data.user_address, data.amount, data.timestamp are now available

--- a/network-node/src/indexer.rs
+++ b/network-node/src/indexer.rs
@@ -115,7 +115,7 @@ impl EventIndexer {
                         info!(
                             event_id = %event.id,
                             ledger = event.ledger,
-                            "Processing AxionVault Soroban event"
+                            "Processing AxVault Soroban event"
                         );
 
                         let protocol = event.topic.get(0).cloned();

--- a/tests/events/event_standards.test.ts
+++ b/tests/events/event_standards.test.ts
@@ -62,7 +62,7 @@ describe('Event Standards', () => {
     it('protocol identifier should be consistent across all events', () => {
       const actions = Object.values(EVENT_ACTIONS);
       for (const action of actions) {
-        expect(PROTOCOL).toBe('AxionVault');
+        expect(PROTOCOL).toBe('AxVault');
         expect(action).toBeDefined();
         expect(action.length).toBeGreaterThan(0);
       }


### PR DESCRIPTION
What was done

Documentation Updates: Standardized docs/EVENTS.md and docs/contract-spec.md to explicitly refer to the protocol identifier as AxVault rather than AxionVault, keeping documentation strictly in sync with the on-chain Rust contract's symbol_short!("AxVault").
Test Alignment: Fixed the constant expectation in tests/events/event_standards.test.ts to assert against AxVault, allowing the rigorous standard suite to execute successfully and validate event formats.
Indexer Adjustments: Modified the network-node/src/indexer.rs to log and parse the AxVault namespace consistently.
Why it was done To ensure complete consistency of our event topics across the protocol. Inconsistent identifiers between documentation, SDK assumptions, and the actual Soroban emitted events cause downstream failures for indexers parsing the two-topic design. This standardization completely reduces this maintenance overhead.

How it was verified

Verified that all documentation properly reflects the new protocol schema logic.
Ran the internal event test suite (event_standards.test.ts), which now correctly executes and validates that all events adhere to the AxVault design.
closes #221 