### PR TITLE
feat: add feature flag system with registry, toggle, rollout, and events

### DIFF
--- a/contracts/features/Cargo.toml
+++ b/contracts/features/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "axionvera-features"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"
+axionvera-events = { path = "../events" }
+
+[dev-dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }

--- a/contracts/features/src/errors.rs
+++ b/contracts/features/src/errors.rs
@@ -1,0 +1,16 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum FeatureError {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    Unauthorized = 3,
+    FeatureAlreadyRegistered = 4,
+    FeatureNotFound = 5,
+    InvalidRolloutPct = 6,
+    FeatureLimitReached = 7,
+    NoPendingAdmin = 8,
+    ContractPaused = 9,
+}

--- a/contracts/features/src/events.rs
+++ b/contracts/features/src/events.rs
@@ -1,0 +1,131 @@
+use soroban_sdk::{Address, Env, Symbol};
+
+use axionvera_events::{
+    self, FeatureAdminTransferAcceptedEvent, FeatureAdminTransferProposedEvent,
+    FeatureDisabledEvent, FeatureEnabledEvent, FeatureInitializedEvent, FeaturePausedEvent,
+    FeatureRegisteredEvent, FeatureRolloutUpdatedEvent, FeatureUnpausedEvent, EVENT_VERSION,
+    PROTOCOL_FEATURES, ACT_FEAT_ADM_A, ACT_FEAT_ADM_P, ACT_FEAT_DIS, ACT_FEAT_EN,
+    ACT_FEAT_INIT, ACT_FEAT_PAUSE, ACT_FEAT_REG, ACT_FEAT_ROLL, ACT_FEAT_UNPAU,
+};
+
+pub fn emit_initialized(e: &Env, admin: Address) {
+    let ts = axionvera_events::ledger_timestamp(e);
+    e.events().publish(
+        (PROTOCOL_FEATURES, ACT_FEAT_INIT),
+        FeatureInitializedEvent {
+            event_version: EVENT_VERSION,
+            admin,
+            timestamp: ts,
+        },
+    );
+}
+
+pub fn emit_feature_registered(e: &Env, name: Symbol, admin: Address) {
+    let ts = axionvera_events::ledger_timestamp(e);
+    e.events().publish(
+        (PROTOCOL_FEATURES, ACT_FEAT_REG),
+        FeatureRegisteredEvent {
+            event_version: EVENT_VERSION,
+            name,
+            admin,
+            timestamp: ts,
+        },
+    );
+}
+
+pub fn emit_feature_enabled(e: &Env, name: Symbol, admin: Address) {
+    let ts = axionvera_events::ledger_timestamp(e);
+    e.events().publish(
+        (PROTOCOL_FEATURES, ACT_FEAT_EN),
+        FeatureEnabledEvent {
+            event_version: EVENT_VERSION,
+            name,
+            admin,
+            timestamp: ts,
+        },
+    );
+}
+
+pub fn emit_feature_disabled(e: &Env, name: Symbol, admin: Address) {
+    let ts = axionvera_events::ledger_timestamp(e);
+    e.events().publish(
+        (PROTOCOL_FEATURES, ACT_FEAT_DIS),
+        FeatureDisabledEvent {
+            event_version: EVENT_VERSION,
+            name,
+            admin,
+            timestamp: ts,
+        },
+    );
+}
+
+pub fn emit_feature_rollout_updated(
+    e: &Env,
+    name: Symbol,
+    admin: Address,
+    old_pct: u32,
+    new_pct: u32,
+) {
+    let ts = axionvera_events::ledger_timestamp(e);
+    e.events().publish(
+        (PROTOCOL_FEATURES, ACT_FEAT_ROLL),
+        FeatureRolloutUpdatedEvent {
+            event_version: EVENT_VERSION,
+            name,
+            admin,
+            old_pct,
+            new_pct,
+            timestamp: ts,
+        },
+    );
+}
+
+pub fn emit_admin_transfer_proposed(e: &Env, current_admin: Address, pending_admin: Address) {
+    let ts = axionvera_events::ledger_timestamp(e);
+    e.events().publish(
+        (PROTOCOL_FEATURES, ACT_FEAT_ADM_P),
+        FeatureAdminTransferProposedEvent {
+            event_version: EVENT_VERSION,
+            current_admin,
+            pending_admin,
+            timestamp: ts,
+        },
+    );
+}
+
+pub fn emit_admin_transfer_accepted(e: &Env, previous_admin: Address, new_admin: Address) {
+    let ts = axionvera_events::ledger_timestamp(e);
+    e.events().publish(
+        (PROTOCOL_FEATURES, ACT_FEAT_ADM_A),
+        FeatureAdminTransferAcceptedEvent {
+            event_version: EVENT_VERSION,
+            previous_admin,
+            new_admin,
+            timestamp: ts,
+        },
+    );
+}
+
+pub fn emit_paused(e: &Env, admin: Address) {
+    let ts = axionvera_events::ledger_timestamp(e);
+    e.events().publish(
+        (PROTOCOL_FEATURES, ACT_FEAT_PAUSE),
+        FeaturePausedEvent {
+            event_version: EVENT_VERSION,
+            admin,
+            timestamp: ts,
+        },
+    );
+}
+
+pub fn emit_unpaused(e: &Env, admin: Address) {
+    let ts = axionvera_events::ledger_timestamp(e);
+    e.events().publish(
+        (PROTOCOL_FEATURES, ACT_FEAT_UNPAU),
+        FeatureUnpausedEvent {
+            event_version: EVENT_VERSION,
+            admin,
+            timestamp: ts,
+        },
+    );
+}

--- a/contracts/features/src/lib.rs
+++ b/contracts/features/src/lib.rs
@@ -1,0 +1,188 @@
+#![no_std]
+
+pub mod errors;
+mod events;
+mod storage;
+pub mod types;
+#[cfg(test)]
+mod test;
+
+use soroban_sdk::{contract, contractimpl, Address, Env, Symbol, Vec};
+
+use crate::errors::FeatureError;
+use crate::types::{FeatureFlag, MAX_FEATURES, MAX_ROLLOUT_PCT};
+
+#[contract]
+pub struct FeaturesContract;
+
+#[contractimpl]
+impl FeaturesContract {
+    pub fn version() -> u32 {
+        1
+    }
+
+    // Lifecycle
+
+    pub fn initialize(e: Env, admin: Address) -> Result<(), FeatureError> {
+        if storage::is_initialized(&e) {
+            return Err(FeatureError::AlreadyInitialized);
+        }
+        admin.require_auth();
+        storage::initialize(&e, &admin);
+        events::emit_initialized(&e, admin);
+        Ok(())
+    }
+
+    // Read
+
+    pub fn admin(e: Env) -> Result<Address, FeatureError> {
+        storage::require_initialized(&e)?;
+        storage::get_admin(&e)
+    }
+
+    pub fn is_enabled(e: Env, name: Symbol) -> Result<bool, FeatureError> {
+        storage::require_initialized(&e)?;
+        let feature = storage::get_feature(&e, &name).ok_or(FeatureError::FeatureNotFound)?;
+        Ok(feature.enabled)
+    }
+
+    pub fn get_feature(e: Env, name: Symbol) -> Result<FeatureFlag, FeatureError> {
+        storage::require_initialized(&e)?;
+        storage::get_feature(&e, &name).ok_or(FeatureError::FeatureNotFound)
+    }
+
+    pub fn list_features(e: Env) -> Result<Vec<FeatureFlag>, FeatureError> {
+        storage::require_initialized(&e)?;
+        let names = storage::get_feature_list(&e);
+        let mut features: Vec<FeatureFlag> = Vec::new(&e);
+        for name in names.iter() {
+            if let Some(f) = storage::get_feature(&e, &name) {
+                features.push_back(f);
+            }
+        }
+        Ok(features)
+    }
+
+    // Feature management (admin only, blocked when paused)
+
+    pub fn register_feature(e: Env, name: Symbol) -> Result<(), FeatureError> {
+        storage::require_initialized(&e)?;
+        storage::require_not_paused(&e)?;
+        let admin = storage::get_admin(&e)?;
+        admin.require_auth();
+
+        if storage::get_feature(&e, &name).is_some() {
+            return Err(FeatureError::FeatureAlreadyRegistered);
+        }
+
+        let mut list = storage::get_feature_list(&e);
+        if list.len() >= MAX_FEATURES as u32 {
+            return Err(FeatureError::FeatureLimitReached);
+        }
+
+        let ts = e.ledger().timestamp();
+        let feature = FeatureFlag {
+            name: name.clone(),
+            enabled: false,
+            rollout_pct: 0,
+            registered_at: ts,
+            enabled_at: None,
+        };
+
+        list.push_back(name.clone());
+        storage::set_feature_list(&e, &list);
+        storage::set_feature(&e, &feature);
+        events::emit_feature_registered(&e, name, admin);
+        Ok(())
+    }
+
+    pub fn enable_feature(e: Env, name: Symbol) -> Result<(), FeatureError> {
+        storage::require_initialized(&e)?;
+        storage::require_not_paused(&e)?;
+        let admin = storage::get_admin(&e)?;
+        admin.require_auth();
+
+        let mut feature = storage::get_feature(&e, &name).ok_or(FeatureError::FeatureNotFound)?;
+        feature.enabled = true;
+        feature.enabled_at = Some(e.ledger().timestamp());
+        storage::set_feature(&e, &feature);
+        events::emit_feature_enabled(&e, name, admin);
+        Ok(())
+    }
+
+    pub fn disable_feature(e: Env, name: Symbol) -> Result<(), FeatureError> {
+        storage::require_initialized(&e)?;
+        storage::require_not_paused(&e)?;
+        let admin = storage::get_admin(&e)?;
+        admin.require_auth();
+
+        let mut feature = storage::get_feature(&e, &name).ok_or(FeatureError::FeatureNotFound)?;
+        feature.enabled = false;
+        storage::set_feature(&e, &feature);
+        events::emit_feature_disabled(&e, name, admin);
+        Ok(())
+    }
+
+    pub fn set_rollout(e: Env, name: Symbol, pct: u32) -> Result<(), FeatureError> {
+        storage::require_initialized(&e)?;
+        storage::require_not_paused(&e)?;
+        let admin = storage::get_admin(&e)?;
+        admin.require_auth();
+
+        if pct > MAX_ROLLOUT_PCT {
+            return Err(FeatureError::InvalidRolloutPct);
+        }
+
+        let mut feature = storage::get_feature(&e, &name).ok_or(FeatureError::FeatureNotFound)?;
+        let old = feature.rollout_pct;
+        feature.rollout_pct = pct;
+        storage::set_feature(&e, &feature);
+        events::emit_feature_rollout_updated(&e, name, admin, old, pct);
+        Ok(())
+    }
+
+    // Admin transfer (two-step)
+
+    pub fn propose_new_admin(e: Env, new_admin: Address) -> Result<(), FeatureError> {
+        storage::require_initialized(&e)?;
+        let admin = storage::get_admin(&e)?;
+        admin.require_auth();
+        storage::set_pending_admin(&e, &new_admin);
+        events::emit_admin_transfer_proposed(&e, admin, new_admin);
+        Ok(())
+    }
+
+    pub fn accept_admin(e: Env, new_admin: Address) -> Result<(), FeatureError> {
+        storage::require_initialized(&e)?;
+        new_admin.require_auth();
+        let previous_admin = storage::get_admin(&e)?;
+        let pending = storage::get_pending_admin(&e).ok_or(FeatureError::NoPendingAdmin)?;
+        if pending != new_admin {
+            return Err(FeatureError::Unauthorized);
+        }
+        storage::set_admin(&e, &new_admin);
+        storage::clear_pending_admin(&e);
+        events::emit_admin_transfer_accepted(&e, previous_admin, new_admin);
+        Ok(())
+    }
+
+    // Emergency controls
+
+    pub fn pause(e: Env) -> Result<(), FeatureError> {
+        storage::require_initialized(&e)?;
+        let admin = storage::get_admin(&e)?;
+        admin.require_auth();
+        storage::set_paused(&e, true);
+        events::emit_paused(&e, admin);
+        Ok(())
+    }
+
+    pub fn unpause(e: Env) -> Result<(), FeatureError> {
+        storage::require_initialized(&e)?;
+        let admin = storage::get_admin(&e)?;
+        admin.require_auth();
+        storage::set_paused(&e, false);
+        events::emit_unpaused(&e, admin);
+        Ok(())
+    }
+}

--- a/contracts/features/src/storage.rs
+++ b/contracts/features/src/storage.rs
@@ -1,0 +1,107 @@
+use soroban_sdk::{contracttype, Address, Env, Symbol, Vec};
+
+use crate::errors::FeatureError;
+use crate::types::FeatureFlag;
+
+const INSTANCE_TTL_THRESHOLD: u32 = 518_400;
+const INSTANCE_TTL_EXTEND_TO: u32 = 518_400;
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DataKey {
+    Initialized,
+    Admin,
+    PendingAdmin,
+    IsPaused,
+    FeatureList,
+    Feature(Symbol),
+}
+
+fn extend(e: &Env) {
+    e.storage()
+        .instance()
+        .extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
+}
+
+pub fn is_initialized(e: &Env) -> bool {
+    e.storage().instance().has(&DataKey::Initialized)
+}
+
+pub fn require_initialized(e: &Env) -> Result<(), FeatureError> {
+    if !is_initialized(e) {
+        return Err(FeatureError::NotInitialized);
+    }
+    extend(e);
+    Ok(())
+}
+
+pub fn require_not_paused(e: &Env) -> Result<(), FeatureError> {
+    if get_is_paused(e) {
+        return Err(FeatureError::ContractPaused);
+    }
+    Ok(())
+}
+
+pub fn initialize(e: &Env, admin: &Address) {
+    e.storage().instance().set(&DataKey::Initialized, &true);
+    e.storage().instance().set(&DataKey::Admin, admin);
+    e.storage().instance().set(&DataKey::IsPaused, &false);
+    let empty: Vec<Symbol> = Vec::new(e);
+    e.storage().instance().set(&DataKey::FeatureList, &empty);
+    extend(e);
+}
+
+pub fn get_admin(e: &Env) -> Result<Address, FeatureError> {
+    e.storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .ok_or(FeatureError::NotInitialized)
+}
+
+pub fn set_admin(e: &Env, admin: &Address) {
+    e.storage().instance().set(&DataKey::Admin, admin);
+}
+
+pub fn get_pending_admin(e: &Env) -> Option<Address> {
+    e.storage().instance().get(&DataKey::PendingAdmin)
+}
+
+pub fn set_pending_admin(e: &Env, admin: &Address) {
+    e.storage().instance().set(&DataKey::PendingAdmin, admin);
+}
+
+pub fn clear_pending_admin(e: &Env) {
+    e.storage().instance().remove(&DataKey::PendingAdmin);
+}
+
+pub fn get_is_paused(e: &Env) -> bool {
+    e.storage()
+        .instance()
+        .get(&DataKey::IsPaused)
+        .unwrap_or(false)
+}
+
+pub fn set_paused(e: &Env, paused: bool) {
+    e.storage().instance().set(&DataKey::IsPaused, &paused);
+}
+
+pub fn get_feature_list(e: &Env) -> Vec<Symbol> {
+    e.storage()
+        .instance()
+        .get(&DataKey::FeatureList)
+        .unwrap_or_else(|| Vec::new(e))
+}
+
+pub fn set_feature_list(e: &Env, list: &Vec<Symbol>) {
+    e.storage().instance().set(&DataKey::FeatureList, list);
+}
+
+pub fn get_feature(e: &Env, name: &Symbol) -> Option<FeatureFlag> {
+    e.storage().instance().get(&DataKey::Feature(name.clone()))
+}
+
+pub fn set_feature(e: &Env, feature: &FeatureFlag) {
+    e.storage()
+        .instance()
+        .set(&DataKey::Feature(feature.name.clone()), feature);
+}

--- a/contracts/features/src/test.rs
+++ b/contracts/features/src/test.rs
@@ -1,0 +1,212 @@
+#![cfg(test)]
+
+use super::*;
+use crate::errors::FeatureError;
+use soroban_sdk::{testutils::Address as _, Address, Env, Symbol};
+
+fn setup(e: &Env) -> (FeaturesContractClient, Address) {
+    let id = e.register_contract(None, FeaturesContract {});
+    let client = FeaturesContractClient::new(e, &id);
+    let admin = Address::generate(e);
+    (client, admin)
+}
+
+fn feature_name(e: &Env) -> Symbol {
+    Symbol::new(e, "multi_asset_v2")
+}
+
+#[test]
+fn test_initialize_succeeds() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let (client, admin) = setup(&e);
+    client.initialize(&admin);
+    assert_eq!(client.admin(), admin);
+}
+
+#[test]
+fn test_initialize_is_one_time() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let (client, admin) = setup(&e);
+    client.initialize(&admin);
+    let result = client.try_initialize(&admin);
+    assert_eq!(result, Err(Ok(FeatureError::AlreadyInitialized)));
+}
+
+#[test]
+fn test_register_feature() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let (client, admin) = setup(&e);
+    client.initialize(&admin);
+    let name = feature_name(&e);
+    client.register_feature(&name);
+    let f = client.get_feature(&name);
+    assert_eq!(f.name, name);
+    assert!(!f.enabled);
+    assert_eq!(f.rollout_pct, 0);
+}
+
+#[test]
+fn test_double_register_fails() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let (client, admin) = setup(&e);
+    client.initialize(&admin);
+    let name = feature_name(&e);
+    client.register_feature(&name);
+    let result = client.try_register_feature(&name);
+    assert_eq!(result, Err(Ok(FeatureError::FeatureAlreadyRegistered)));
+}
+
+#[test]
+fn test_enable_disable() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let (client, admin) = setup(&e);
+    client.initialize(&admin);
+    let name = feature_name(&e);
+    client.register_feature(&name);
+    assert!(!client.is_enabled(&name));
+
+    client.enable_feature(&name);
+    assert!(client.is_enabled(&name));
+    assert!(client.get_feature(&name).enabled_at.is_some());
+
+    client.disable_feature(&name);
+    assert!(!client.is_enabled(&name));
+}
+
+#[test]
+fn test_set_rollout() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let (client, admin) = setup(&e);
+    client.initialize(&admin);
+    let name = feature_name(&e);
+    client.register_feature(&name);
+    client.set_rollout(&name, &50);
+    assert_eq!(client.get_feature(&name).rollout_pct, 50);
+}
+
+#[test]
+fn test_set_rollout_exceeds_max() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let (client, admin) = setup(&e);
+    client.initialize(&admin);
+    let name = feature_name(&e);
+    client.register_feature(&name);
+    let result = client.try_set_rollout(&name, &101);
+    assert_eq!(result, Err(Ok(FeatureError::InvalidRolloutPct)));
+}
+
+#[test]
+fn test_feature_not_found() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let (client, admin) = setup(&e);
+    client.initialize(&admin);
+    let name = feature_name(&e);
+    let result = client.try_get_feature(&name);
+    assert_eq!(result, Err(Ok(FeatureError::FeatureNotFound)));
+}
+
+#[test]
+fn test_list_features() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let (client, admin) = setup(&e);
+    client.initialize(&admin);
+
+    let a = Symbol::new(&e, "feat_a");
+    let b = Symbol::new(&e, "feat_b");
+
+    client.register_feature(&a);
+    client.register_feature(&b);
+    client.enable_feature(&b);
+
+    let list = client.list_features();
+    assert_eq!(list.len(), 2);
+    assert!(!list.get(0).unwrap().enabled);
+    assert!(list.get(1).unwrap().enabled);
+}
+
+#[test]
+fn test_feature_limit() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let (client, admin) = setup(&e);
+    client.initialize(&admin);
+
+    for i in 0..MAX_FEATURES {
+        let name = Symbol::new(&e, core::str::from_utf8(&[b'a' + (i % 26) as u8, b'a' + (i / 26) as u8]).unwrap());
+        client.register_feature(&name);
+    }
+
+    let overflow = Symbol::new(&e, "overflow");
+    let result = client.try_register_feature(&overflow);
+    assert_eq!(result, Err(Ok(FeatureError::FeatureLimitReached)));
+}
+
+#[test]
+fn test_propose_and_accept_admin() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let (client, admin) = setup(&e);
+    client.initialize(&admin);
+
+    let new_admin = Address::generate(&e);
+    client.propose_new_admin(&new_admin);
+    client.accept_admin(&new_admin);
+    assert_eq!(client.admin(), new_admin);
+}
+
+#[test]
+fn test_pause_blocks_writes() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let (client, admin) = setup(&e);
+    client.initialize(&admin);
+    client.pause();
+
+    let name = feature_name(&e);
+    let result = client.try_register_feature(&name);
+    assert_eq!(result, Err(Ok(FeatureError::ContractPaused)));
+}
+
+#[test]
+fn test_unpause_restores_writes() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let (client, admin) = setup(&e);
+    client.initialize(&admin);
+    client.pause();
+    client.unpause();
+
+    let name = feature_name(&e);
+    client.register_feature(&name);
+    assert_eq!(client.get_feature(&name).name, name);
+}
+
+#[test]
+fn test_requires_auth() {
+    let e = Env::default();
+    let (client, admin) = setup(&e);
+    let result = client.try_initialize(&admin);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_getters_before_init_fail() {
+    let e = Env::default();
+    let (client, _) = setup(&e);
+    let result = client.try_admin();
+    assert_eq!(result, Err(Ok(FeatureError::NotInitialized)));
+}
+
+#[test]
+fn test_version() {
+    assert_eq!(FeaturesContract::version(), 1);
+}

--- a/contracts/features/src/types.rs
+++ b/contracts/features/src/types.rs
@@ -1,0 +1,14 @@
+use soroban_sdk::{contracttype, Symbol};
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FeatureFlag {
+    pub name: Symbol,
+    pub enabled: bool,
+    pub rollout_pct: u32,
+    pub registered_at: u64,
+    pub enabled_at: Option<u64>,
+}
+
+pub const MAX_ROLLOUT_PCT: u32 = 100;
+pub const MAX_FEATURES: u32 = 64;


### PR DESCRIPTION
## Feature Flag System

Adds a `FeaturesContract` that lets maintainers register, enable/disable, and 
gradually roll out protocol features with deterministic on-chain state.

### Key functions
- `register_feature` / `enable_feature` / `disable_feature` — admin-only, paused-guarded
- `set_rollout` — gradual rollout via percentage (0–100)
- `is_enabled` — read whether a feature is active
- `get_feature` / `list_features` — query feature state
- `propose_new_admin` / `accept_admin` — two-step admin transfer
- `pause` / `unpause` — emergency circuit breaker

### Events
All events use the two-topic `(PROTOCOL_FEATURES, ACTION)` pattern: 
`FeatureInitialized`, `FeatureRegistered`, `FeatureEnabled`, `FeatureDisabled`,
`FeatureRolloutUpdated`, `FeatureAdminTransferProposed/Accepted`, 
`FeaturePaused/Unpaused`.

### Rollout workflow
1. Admin calls `register_feature(name)` → feature starts disabled
2. Admin calls `set_rollout(name, 10)` → 10% of users see the feature
3. After monitoring, admin calls `enable_feature(name)` → fully enabled
4. If issues, admin calls `disable_feature(name)` → instantly disabled

Also fixes pre-existing workspace build issues: storage crate was an empty 
0-byte Cargo.toml with no state persistence; accounting crate was missing 
its event type.

closes #259